### PR TITLE
fix: override AutoIP GetZones method

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -173,8 +173,9 @@ namespace Certify.Providers.DNS.AutoIP
             }
         }
 
-        public Task<List<DnsZone>> GetZones()
+        public override Task<List<DnsZone>> GetZones()
         {
+            // AutoIP API does not provide a way to enumerate zones, so return an empty list.
             return Task.FromResult(new List<DnsZone>());
         }
     }


### PR DESCRIPTION
## Summary
- mark AutoIP provider GetZones as override and document absence of zone enumeration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6698da2ac832eb5caedda55111941