### PR TITLE
Add delete option to credential editor

### DIFF
--- a/src/Certify.UI.Shared/Windows/EditCredential.xaml
+++ b/src/Certify.UI.Shared/Windows/EditCredential.xaml
@@ -147,7 +147,7 @@
             </ItemsControl>
         </ScrollViewer>
 
-        <DockPanel DockPanel.Dock="Bottom">
+        <DockPanel DockPanel.Dock="Bottom" LastChildFill="False">
             <Button
                 x:Name="Cancel"
                 Width="75"
@@ -166,6 +166,29 @@
                 Click="Save_Click"
                 Content="Save"
                 DockPanel.Dock="Right" />
+            <Button
+                x:Name="Delete"
+                Width="77"
+                Margin="16,0,0,0"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Top"
+                Click="Delete_Click"
+                Content="Delete"
+                DockPanel.Dock="Right">
+                <Button.Style>
+                    <Style TargetType="Button">
+                        <Setter Property="IsEnabled" Value="True" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding Item.StorageKey}" Value="{x:Null}">
+                                <Setter Property="IsEnabled" Value="False" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding Item.StorageKey}" Value="">
+                                <Setter Property="IsEnabled" Value="False" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
         </DockPanel>
     </DockPanel>
 </Controls:MetroWindow>

--- a/src/Certify.UI.Shared/Windows/EditCredential.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/EditCredential.xaml.cs
@@ -175,6 +175,27 @@ namespace Certify.UI.Windows
 
         private void Cancel_Click(object sender, System.Windows.RoutedEventArgs e) => Close();
 
+        private async void Delete_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (EditViewModel?.Item?.StorageKey == null)
+            {
+                return;
+            }
+
+            if (MessageBox.Show("Are you sure you wish to delete this stored credential?", "Confirm Delete", MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
+            {
+                var result = await MainViewModel.DeleteCredential(EditViewModel.Item.StorageKey);
+                if (result.IsSuccess)
+                {
+                    Close();
+                }
+                else
+                {
+                    MessageBox.Show(result.Message);
+                }
+            }
+        }
+
         private void HelpUrl_RequestNavigate(object sender, System.Windows.Navigation.RequestNavigateEventArgs e)
         {
             e.Handled = true;


### PR DESCRIPTION
## Summary
- add Delete button to credential editor alongside Save and Cancel
- implement Delete_Click handler to confirm removal, call MainViewModel.DeleteCredential and close window on success
- enable Delete only when editing an existing credential

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6952fe284832e8e723ddb5b46552a