### PR TITLE
Fix AutoIP DNS hostname handling and add tests

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -99,7 +99,7 @@ namespace Certify.Providers.DNS.AutoIP
                     { "txt", request.RecordValue }
                 };
 
-                if (!string.IsNullOrEmpty(_password) && !string.IsNullOrEmpty(_hostname))
+                if (!string.IsNullOrEmpty(_hostname))
                 {
                     payload.Add("hostname", _hostname);
                 }
@@ -125,12 +125,12 @@ namespace Certify.Providers.DNS.AutoIP
             try
             {
                 var payload = new Dictionary<string, string>();
-                if (!string.IsNullOrEmpty(_password) && !string.IsNullOrEmpty(_hostname))
+                if (!string.IsNullOrEmpty(_hostname))
                 {
                     payload.Add("hostname", _hostname);
                 }
 
-                var json = JsonConvert.SerializeObject(payload);
+                var json = payload.Count > 0 ? JsonConvert.SerializeObject(payload) : string.Empty;
                 var req = new HttpRequestMessage(HttpMethod.Delete, _apiEndpoint)
                 {
                     Content = new StringContent(json, Encoding.UTF8, "application/json")

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Certify.Models.Providers;
+using Certify.Providers.DNS.AutoIP;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace Certify.Core.Tests.Unit
+{
+    [TestClass]
+    public class DnsProviderAutoIPTests
+    {
+        private class MockHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage? LastRequest { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            }
+        }
+
+        private static async Task<(DnsProviderAutoIP provider, MockHandler handler)> SetupAsync(Dictionary<string, string> creds, Dictionary<string, string> parameters)
+        {
+            var provider = new DnsProviderAutoIP();
+            await provider.InitProvider(creds, parameters, null);
+
+            var handler = new MockHandler();
+            var httpField = typeof(DnsProviderAutoIP).GetField("_http", BindingFlags.NonPublic | BindingFlags.Instance);
+            var existingHttp = (HttpClient)httpField!.GetValue(provider)!;
+            var http = new HttpClient(handler);
+            http.DefaultRequestHeaders.Authorization = existingHttp.DefaultRequestHeaders.Authorization;
+            httpField.SetValue(provider, http);
+            return (provider, handler);
+        }
+
+        [TestMethod]
+        public async Task CreateAndDelete_WithTokenAndHostname()
+        {
+            var (provider, handler) = await SetupAsync(
+                new Dictionary<string, string> { ["acmetoken"] = "token" },
+                new Dictionary<string, string> { ["hostname"] = "test.example.com" });
+
+            var createResult = await provider.CreateRecord(new DnsRecord { RecordValue = "txtvalue" });
+            var createContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
+            var createJson = JObject.Parse(createContent);
+            Assert.AreEqual("txtvalue", createJson["txt"]!.ToString());
+            Assert.AreEqual("test.example.com", createJson["hostname"]!.ToString());
+            Assert.AreEqual(2, createJson.Count);
+            Assert.IsTrue(createResult.IsSuccess);
+
+            var deleteResult = await provider.DeleteRecord(new DnsRecord());
+            var deleteContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
+            var deleteJson = JObject.Parse(deleteContent);
+            Assert.AreEqual("test.example.com", deleteJson["hostname"]!.ToString());
+            Assert.AreEqual(1, deleteJson.Count);
+            Assert.IsTrue(deleteResult.IsSuccess);
+        }
+
+        [TestMethod]
+        public async Task CreateAndDelete_WithUserPassword_NoHostname()
+        {
+            var (provider, handler) = await SetupAsync(
+                new Dictionary<string, string> { ["username"] = "user", ["password"] = "pass" },
+                new Dictionary<string, string>());
+
+            var createResult = await provider.CreateRecord(new DnsRecord { RecordValue = "txtvalue" });
+            var createContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
+            var createJson = JObject.Parse(createContent);
+            Assert.AreEqual("txtvalue", createJson["txt"]!.ToString());
+            Assert.AreEqual(1, createJson.Count);
+            Assert.IsTrue(createResult.IsSuccess);
+
+            var deleteResult = await provider.DeleteRecord(new DnsRecord());
+            var deleteContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
+            Assert.AreEqual(string.Empty, deleteContent);
+            Assert.IsTrue(deleteResult.IsSuccess);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- fix AutoIP DNS provider to always include hostname when set and send empty body when not
- add unit tests for token and user/password scenarios verifying JSON payloads

## Testing
- `dotnet test src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj --filter DnsProviderAutoIPTests` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a69bcd6a7c832eb96a712f939d008e