### PR TITLE
Log AutoIP DNS API error responses

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -112,7 +112,10 @@ namespace Certify.Providers.DNS.AutoIP
                     return new ActionResult { IsSuccess = true, Message = "DNS record added." };
                 }
 
-                return new ActionResult { IsSuccess = false, Message = $"API call failed: {resp.StatusCode}" };
+                var error = await resp.Content.ReadAsStringAsync();
+                var message = $"API call failed: {resp.StatusCode} - {error}";
+                _log?.Error(message);
+                return new ActionResult { IsSuccess = false, Message = message };
             }
             catch (Exception ex)
             {
@@ -142,7 +145,10 @@ namespace Certify.Providers.DNS.AutoIP
                     return new ActionResult { IsSuccess = true, Message = "DNS record removed." };
                 }
 
-                return new ActionResult { IsSuccess = false, Message = $"API call failed: {resp.StatusCode}" };
+                var error = await resp.Content.ReadAsStringAsync();
+                var message = $"API call failed: {resp.StatusCode} - {error}";
+                _log?.Error(message);
+                return new ActionResult { IsSuccess = false, Message = message };
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- include API response content when AutoIP DNS API calls fail
- log detailed error messages for AutoIP DNS provider

## Testing
- `dotnet build src/Certify.Providers/Plugin.DNS.AutoIP.csproj` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a69cacc19c832e8f8f3b5ba9709292