### PR TITLE
chore: improve AutoIP DNS provider logging

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -87,6 +87,10 @@ namespace Certify.Providers.DNS.AutoIP
                     _http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", auth);
                 }
             }
+            var authType = string.IsNullOrEmpty(_password) ? "token" : "user";
+            var passwordDisplay = string.IsNullOrEmpty(_password) ? string.Empty : "****";
+            _log?.Information("AutoIP provider initialized. Endpoint: {Endpoint}. AuthType: {AuthType}. Credential: {Credential} {Password}",
+                _apiEndpoint, authType, _credential, passwordDisplay);
 
             return Task.FromResult(true);
         }
@@ -105,6 +109,8 @@ namespace Certify.Providers.DNS.AutoIP
                 }
 
                 var json = JsonConvert.SerializeObject(payload);
+                var authInfo = string.IsNullOrEmpty(_password) ? $"token {_credential}" : $"user {_credential} / ****";
+                _log?.Information("HTTP POST {Url} Payload: {Payload}. Auth: {AuthInfo}", _apiEndpoint, json, authInfo);
                 var resp = await _http.PostAsync(_apiEndpoint, new StringContent(json, Encoding.UTF8, "application/json"));
 
                 if (resp.IsSuccessStatusCode)
@@ -134,6 +140,8 @@ namespace Certify.Providers.DNS.AutoIP
                 }
 
                 var json = payload.Count > 0 ? JsonConvert.SerializeObject(payload) : string.Empty;
+                var authInfo = string.IsNullOrEmpty(_password) ? $"token {_credential}" : $"user {_credential} / ****";
+                _log?.Information("HTTP DELETE {Url} Payload: {Payload}. Auth: {AuthInfo}", _apiEndpoint, json, authInfo);
                 var req = new HttpRequestMessage(HttpMethod.Delete, _apiEndpoint)
                 {
                     Content = new StringContent(json, Encoding.UTF8, "application/json")


### PR DESCRIPTION
## Summary
- log configured endpoint and auth type during initialization
- log HTTP method, endpoint and payload for AutoIP DNS requests

## Testing
- `dotnet build src/Certify.Providers/DNS/AutoIP/Plugin.DNS.AutoIP.csproj` *(failed: command not found)*
- `apt-get update` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a006ec00832ea5916142ccc5d24b