### PR TITLE
Update About page branding

### DIFF
--- a/src/Certify.Locales/ConfigResources.Designer.cs
+++ b/src/Certify.Locales/ConfigResources.Designer.cs
@@ -71,7 +71,7 @@ namespace Certify.Locales {
         
         
         /// <summary>
-        ///   Looks up a localized string similar to Certify Certificate Manager.
+        ///   Looks up a localized string similar to AutoIP Certify.
         /// </summary>
         public static string AppName {
             get {
@@ -89,7 +89,7 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://certifytheweb.com.
+        ///   Looks up a localized string similar to https://kontrol.com.br.
         /// </summary>
         public static string AppWebsiteURL {
             get {
@@ -210,7 +210,7 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certify Certificate Manager.
+        ///   Looks up a localized string similar to AutoIP Certify.
         /// </summary>
         public static string LongAppName {
             get {

--- a/src/Certify.Locales/ConfigResources.resx
+++ b/src/Certify.Locales/ConfigResources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Certify Certificate Manager</value>
+    <value>AutoIP Certify</value>
     <comment>Do not translate</comment>
   </data>
   <data name="Credits" xml:space="preserve">
@@ -132,7 +132,7 @@ This software uses the following Open Source software (or significant portions o
 - OpenSSL (https://github.com/openssl-net/openssl-net)</value>
   </data>
   <data name="LongAppName" xml:space="preserve">
-    <value>Certify Certificate Manager</value>
+    <value>AutoIP Certify</value>
     <comment>Do not translate</comment>
   </data>
   <data name="UpdateCheckLatestVersion" xml:space="preserve">
@@ -143,7 +143,7 @@ This software uses the following Open Source software (or significant portions o
     <comment>Do not translate</comment>
   </data>
   <data name="AppWebsiteURL" xml:space="preserve">
-    <value>https://certifytheweb.com</value>
+    <value>https://kontrol.com.br</value>
     <comment>Do not translate</comment>
   </data>
   <data name="BetaWarning" xml:space="preserve">

--- a/src/Certify.UI.Shared/Controls/AboutControl.xaml
+++ b/src/Certify.UI.Shared/Controls/AboutControl.xaml
@@ -26,7 +26,7 @@
                 x:Name="lblAppTitle"
                 DockPanel.Dock="Top"
                 FontSize="22"
-                TextWrapping="Wrap"><Run FontFamily="Segoe UI Bold" Text="Certify" /><Run FontFamily="Segoe UI" Text=" the web" /></TextBlock>
+                TextWrapping="Wrap"><Run FontFamily="Segoe UI Bold" Text="AutoIP" /><Run FontFamily="Segoe UI" Text=" Certify" /></TextBlock>
             <TextBlock
                 x:Name="lblAppVersion"
                 Margin="0,8"
@@ -36,7 +36,7 @@
                 x:Name="lblAbout"
                 Margin="0,8"
                 DockPanel.Dock="Top"
-                TextWrapping="Wrap"><Run Text="Copyright Webprofusion Pty Ltd 2015 - 2025" /><LineBreak /><Run Text="https://certifytheweb.com" /></TextBlock>
+                TextWrapping="Wrap"><Run Text="Powered by KONTROL" /><LineBreak /><Hyperlink NavigateUri="https://kontrol.com.br" RequestNavigate="Hyperlink_RequestNavigate">https://kontrol.com.br</Hyperlink></TextBlock>
 
             <TextBlock
                 x:Name="lblRegistrationType"

--- a/src/Certify.UI.Shared/Controls/AboutControl.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/AboutControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Navigation;
 using Certify.Locales;
 using Certify.UI.Shared;
 
@@ -92,7 +93,7 @@ namespace Certify.UI.Controls
             }
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://certifytheweb.com/register?src=app");
+        private void Button_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://kontrol.com.br/register?src=app");
 
         private void Button_ApplyRegistrationKey(object sender, RoutedEventArgs e)
         {
@@ -106,7 +107,7 @@ namespace Certify.UI.Controls
             //refresh registration status TODO: main window title
             PopulateAppInfo();
 
-        private void Help_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://certifytheweb.com");
+        private void Help_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://kontrol.com.br");
 
         private void Feedback_Click(object sender, RoutedEventArgs e)
         {
@@ -123,6 +124,15 @@ namespace Certify.UI.Controls
             d.ShowDialog();
 
             d.Unloaded += ApplyRegistration_Completed;
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            e.Handled = true;
+            if (e.Uri != null && e.Uri.IsAbsoluteUri)
+            {
+                Utils.Helpers.LaunchBrowser(e.Uri.ToString());
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- rebrand About panel for AutoIP Certify and link to KONTROL site
- refresh local resource strings for new product name and website

## Testing
- ⚠️ `dotnet build src/Certify.UI.sln` *(missing `dotnet`)*
- ⚠️ `apt-get update` *(repository access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a73c115d24832e984213df5164d92a