### PR TITLE
Remove obsolete license controls from About screen

### DIFF
--- a/src/Certify.UI.Shared/Controls/AboutControl.xaml
+++ b/src/Certify.UI.Shared/Controls/AboutControl.xaml
@@ -37,19 +37,6 @@
                 Margin="0,8"
                 DockPanel.Dock="Top"
                 TextWrapping="Wrap"><Run Text="Powered by KONTROL" /><LineBreak /><Hyperlink NavigateUri="https://kontrol.com.br" RequestNavigate="Hyperlink_RequestNavigate">https://kontrol.com.br</Hyperlink></TextBlock>
-
-            <TextBlock
-                x:Name="lblRegistrationType"
-                Margin="0,8"
-                DockPanel.Dock="Top"
-                FontWeight="Bold"
-                Text="{x:Static res:SR.AboutControl_RegistrationTypeLabel}"
-                TextWrapping="Wrap" />
-            <TextBlock
-                x:Name="lblRegistrationDetails"
-                DockPanel.Dock="Top"
-                Style="{StaticResource Instructions}"
-                TextWrapping="Wrap"><Run Text="{x:Static res:SR.AboutControl_TrialDetailLabel}" /></TextBlock>
             <Expander
                 Width="600"
                 Margin="0,32,0,0"
@@ -81,28 +68,6 @@
                 Click="UpdateCheck_Click"
                 Content="{x:Static res:SR.AboutControl_CheckForUpdateButton}"
                 DockPanel.Dock="Top" />
-
-
-            <Button
-                x:Name="ValidateKey"
-                Width="150"
-                Margin="0,24,0,8"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Top"
-                Click="Button_ApplyRegistrationKey"
-                Content="Add License Key.."
-                DockPanel.Dock="Top" />
-
-            <Button
-                x:Name="DeactivateInstall"
-                Width="150"
-                Margin="0,0,0,8"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Top"
-                Click="DeactivateInstall_Click"
-                Content="Remove License Key.."
-                DockPanel.Dock="Top" />
-
             <Button
                 x:Name="Help"
                 Width="150"
@@ -118,7 +83,6 @@
                 Margin="0,0,0,8"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
-                Click="Button_Click"
                 Content="{x:Static res:SR.AboutControl_Register}"
                 DockPanel.Dock="Top" />
 

--- a/src/Certify.UI.Shared/Controls/AboutControl.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/AboutControl.xaml.cs
@@ -23,25 +23,7 @@ namespace Certify.UI.Controls
 
         private void PopulateAppInfo()
         {
-
             lblAppVersion.Text = ConfigResources.AppName + " " + Management.Util.GetAppVersion();
-
-            if (MainViewModel.IsRegisteredVersion)
-            {
-                Register.IsEnabled = false;
-                ValidateKey.IsEnabled = false;
-                DeactivateInstall.IsEnabled = true;
-
-                lblRegistrationType.Text = "Licensed Version";
-                lblRegistrationDetails.Text = "";
-            }
-            else
-            {
-                DeactivateInstall.IsEnabled = false;
-                ValidateKey.IsEnabled = true;
-                Register.IsEnabled = true;
-                lblRegistrationType.Text = "Community Edition (Not Licensed)";
-            }
 
             creditLibs.Text = "";
 
@@ -93,20 +75,6 @@ namespace Certify.UI.Controls
             }
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://kontrol.com.br/register?src=app");
-
-        private void Button_ApplyRegistrationKey(object sender, RoutedEventArgs e)
-        {
-            var d = new Windows.Registration { Owner = Window.GetWindow(this) };
-            d.ShowDialog();
-
-            d.Unloaded += ApplyRegistration_Completed;
-        }
-
-        private void ApplyRegistration_Completed(object sender, EventArgs e) =>
-            //refresh registration status TODO: main window title
-            PopulateAppInfo();
-
         private void Help_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://kontrol.com.br");
 
         private void Feedback_Click(object sender, RoutedEventArgs e)
@@ -116,15 +84,6 @@ namespace Certify.UI.Controls
         }
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e) => PopulateAppInfo();
-
-        private void DeactivateInstall_Click(object sender, RoutedEventArgs e)
-        {
-            var d = new Windows.Registration { Owner = Window.GetWindow(this) };
-            d.EditModel.IsRegistrationMode = false;
-            d.ShowDialog();
-
-            d.Unloaded += ApplyRegistration_Completed;
-        }
 
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {


### PR DESCRIPTION
## Summary
- drop license management controls from About panel
- clean up code-behind by removing registration handlers and license-specific logic

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a73ff309f8832e8aca69e0e613f3ae