### PR TITLE
chore: remove support and register buttons

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -97,15 +97,6 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Purchase License Key...
-        /// </summary>
-        public static string AboutControl_Register {
-            get {
-                return ResourceManager.GetString("AboutControl_Register", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Not Registered.
         /// </summary>
         public static string AboutControl_RegistrationTypeLabel {
@@ -120,15 +111,6 @@ namespace Certify.Locales {
         public static string AboutControl_SendFeedback {
             get {
                 return ResourceManager.GetString("AboutControl_SendFeedback", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Support.
-        /// </summary>
-        public static string AboutControl_Support {
-            get {
-                return ResourceManager.GetString("AboutControl_Support", resourceCulture);
             }
         }
         

--- a/src/Certify.Locales/SR.es-ES.resx
+++ b/src/Certify.Locales/SR.es-ES.resx
@@ -267,14 +267,8 @@
   <data name="AboutControl_CheckForUpdateButton" xml:space="preserve">
     <value>Buscar actualizaciones...</value>
   </data>
-  <data name="AboutControl_Register" xml:space="preserve">
-    <value>Registrar</value>
-  </data>
   <data name="AboutControl_EnterKey" xml:space="preserve">
     <value>Introducir clave...</value>
-  </data>
-  <data name="AboutControl_Support" xml:space="preserve">
-    <value>Soporte</value>
   </data>
   <data name="AboutControl_SendFeedback" xml:space="preserve">
     <value>Enviar Comentarios</value>

--- a/src/Certify.Locales/SR.ja-JP.resx
+++ b/src/Certify.Locales/SR.ja-JP.resx
@@ -255,14 +255,8 @@
   <data name="AboutControl_CheckForUpdateButton" xml:space="preserve">
     <value>アップデートの確認..</value>
   </data>
-  <data name="AboutControl_Register" xml:space="preserve">
-    <value>登録</value>
-  </data>
   <data name="AboutControl_EnterKey" xml:space="preserve">
     <value>キーの入力</value>
-  </data>
-  <data name="AboutControl_Support" xml:space="preserve">
-    <value>サポート</value>
   </data>
   <data name="AboutControl_SendFeedback" xml:space="preserve">
     <value>フィードバックの送信</value>

--- a/src/Certify.Locales/SR.nb-NO.resx
+++ b/src/Certify.Locales/SR.nb-NO.resx
@@ -252,14 +252,8 @@
   <data name="AboutControl_CheckForUpdateButton" xml:space="preserve">
     <value>Se etter oppdateringer...</value>
   </data>
-  <data name="AboutControl_Register" xml:space="preserve">
-    <value>Registrer</value>
-  </data>
   <data name="AboutControl_EnterKey" xml:space="preserve">
     <value>Skriv inn nøkkel...</value>
-  </data>
-  <data name="AboutControl_Support" xml:space="preserve">
-    <value>Support</value>
   </data>
   <data name="AboutControl_SendFeedback" xml:space="preserve">
     <value>Send tilbakemelding</value>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -267,14 +267,8 @@
   <data name="AboutControl_CheckForUpdateButton" xml:space="preserve">
     <value>Check for Updates..</value>
   </data>
-  <data name="AboutControl_Register" xml:space="preserve">
-    <value>Purchase License Key..</value>
-  </data>
   <data name="AboutControl_EnterKey" xml:space="preserve">
     <value>Enter Key..</value>
-  </data>
-  <data name="AboutControl_Support" xml:space="preserve">
-    <value>Support</value>
   </data>
   <data name="AboutControl_SendFeedback" xml:space="preserve">
     <value>Send Feedback</value>

--- a/src/Certify.Locales/SR.tr-TR.resx
+++ b/src/Certify.Locales/SR.tr-TR.resx
@@ -267,14 +267,8 @@
   <data name="AboutControl_CheckForUpdateButton" xml:space="preserve">
     <value>Güncellemeleri kontrol et..</value>
   </data>
-  <data name="AboutControl_Register" xml:space="preserve">
-    <value>Kayıt ol</value>
-  </data>
   <data name="AboutControl_EnterKey" xml:space="preserve">
     <value>Anahtarı Girin..</value>
-  </data>
-  <data name="AboutControl_Support" xml:space="preserve">
-    <value>Destek</value>
   </data>
   <data name="AboutControl_SendFeedback" xml:space="preserve">
     <value>Geribildirim yolla</value>

--- a/src/Certify.Locales/SR.zh-Hans.resx
+++ b/src/Certify.Locales/SR.zh-Hans.resx
@@ -267,14 +267,8 @@
   <data name="AboutControl_CheckForUpdateButton" xml:space="preserve">
     <value>检查更新…</value>
   </data>
-  <data name="AboutControl_Register" xml:space="preserve">
-    <value>购买授权密钥…</value>
-  </data>
   <data name="AboutControl_EnterKey" xml:space="preserve">
     <value>输入密钥…</value>
-  </data>
-  <data name="AboutControl_Support" xml:space="preserve">
-    <value>支持</value>
   </data>
   <data name="AboutControl_SendFeedback" xml:space="preserve">
     <value>提交反馈</value>

--- a/src/Certify.Locales/SR.zh-Hant.resx
+++ b/src/Certify.Locales/SR.zh-Hant.resx
@@ -267,14 +267,8 @@
   <data name="AboutControl_CheckForUpdateButton" xml:space="preserve">
     <value>檢查更新...</value>
   </data>
-  <data name="AboutControl_Register" xml:space="preserve">
-    <value>購買授權金鑰...</value>
-  </data>
   <data name="AboutControl_EnterKey" xml:space="preserve">
     <value>輸入金鑰...</value>
-  </data>
-  <data name="AboutControl_Support" xml:space="preserve">
-    <value>技術支援</value>
   </data>
   <data name="AboutControl_SendFeedback" xml:space="preserve">
     <value>意見回饋</value>

--- a/src/Certify.UI.Shared/Controls/AboutControl.xaml
+++ b/src/Certify.UI.Shared/Controls/AboutControl.xaml
@@ -68,23 +68,6 @@
                 Click="UpdateCheck_Click"
                 Content="{x:Static res:SR.AboutControl_CheckForUpdateButton}"
                 DockPanel.Dock="Top" />
-            <Button
-                x:Name="Help"
-                Width="150"
-                Margin="0,24,0,8"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Top"
-                Click="Help_Click"
-                Content="{x:Static res:SR.AboutControl_Support}"
-                DockPanel.Dock="Top" />
-            <Button
-                x:Name="Register"
-                Width="150"
-                Margin="0,0,0,8"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Top"
-                Content="{x:Static res:SR.AboutControl_Register}"
-                DockPanel.Dock="Top" />
 
         </DockPanel>
 

--- a/src/Certify.UI.Shared/Controls/AboutControl.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/AboutControl.xaml.cs
@@ -75,8 +75,6 @@ namespace Certify.UI.Controls
             }
         }
 
-        private void Help_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://kontrol.com.br");
-
         private void Feedback_Click(object sender, RoutedEventArgs e)
         {
             var d = new Windows.Feedback("", false) { Owner = Window.GetWindow(this) };


### PR DESCRIPTION
## Summary
- remove Help and Register buttons from About tab
- drop unused Help_Click handler
- clean up unused localization entries

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a745a5b198832ea12788b1d6e01d2e