### PR TITLE
Rename Managed Certificates tab and remove unused localization

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -610,15 +610,6 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Managed Certificates.
-        /// </summary>
-        public static string Managed_Certificates {
-            get {
-                return ResourceManager.GetString("Managed_Certificates", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to  Managed Certificates.
         /// </summary>
         public static string Managed_Sites {

--- a/src/Certify.Locales/SR.es-ES.resx
+++ b/src/Certify.Locales/SR.es-ES.resx
@@ -628,9 +628,6 @@
   <data name="Update_DownloadFailed" xml:space="preserve">
     <value>Lo sentimos, no se pudo descargar la actualización. Por favor, inténtelo de nuevo más tarde. </value>
   </data>
-  <data name="Managed_Certificates" xml:space="preserve">
-    <value>Administrar Certificados</value>
-  </data>
   <data name="ManagedCertificateSettings_DefaultTitle" xml:space="preserve">
     <value>Nuevo certificado administrado</value>
   </data>

--- a/src/Certify.Locales/SR.ja-JP.resx
+++ b/src/Certify.Locales/SR.ja-JP.resx
@@ -612,9 +612,6 @@
   <data name="Update_DownloadFailed" xml:space="preserve">
     <value>申し訳ありませんが、アップデートをダウンロードできませんでした。 後でもう一度お試しください。</value>
   </data>
-  <data name="Managed_Certificates" xml:space="preserve">
-    <value>証明書の管理</value>
-  </data>
   <data name="ManagedCertificateSettings_DefaultTitle" xml:space="preserve">
     <value>新しい管理証明書</value>
   </data>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -630,9 +630,6 @@ for the certification process to work.</value>
   <data name="Update_DownloadFailed" xml:space="preserve">
     <value>Sorry, the update could not be downloaded. Please try again later.</value>
   </data>
-  <data name="Managed_Certificates" xml:space="preserve">
-    <value>Managed Certificates</value>
-  </data>
   <data name="ManagedCertificateSettings_DefaultTitle" xml:space="preserve">
     <value>New Managed Certificate</value>
   </data>

--- a/src/Certify.Locales/SR.tr-TR.resx
+++ b/src/Certify.Locales/SR.tr-TR.resx
@@ -626,9 +626,6 @@
   <data name="Update_DownloadFailed" xml:space="preserve">
     <value>Maalesef güncelleme indirilemedi. Lütfen daha sonra tekrar deneyiniz.</value>
   </data>
-  <data name="Managed_Certificates" xml:space="preserve">
-    <value>Yönetilen Sertifikalar</value>
-  </data>
   <data name="ManagedCertificateSettings_DefaultTitle" xml:space="preserve">
     <value>Yeni Yönetilen Sertifika</value>
   </data>

--- a/src/Certify.Locales/SR.zh-Hans.resx
+++ b/src/Certify.Locales/SR.zh-Hans.resx
@@ -629,9 +629,6 @@
   <data name="Update_DownloadFailed" xml:space="preserve">
     <value>抱歉，更新下载失败，请稍候重试。</value>
   </data>
-  <data name="Managed_Certificates" xml:space="preserve">
-    <value>托管证书</value>
-  </data>
   <data name="ManagedCertificateSettings_DefaultTitle" xml:space="preserve">
     <value>新建托管证书</value>
   </data>

--- a/src/Certify.Locales/SR.zh-Hant.resx
+++ b/src/Certify.Locales/SR.zh-Hant.resx
@@ -629,9 +629,6 @@
   <data name="Update_DownloadFailed" xml:space="preserve">
     <value>很抱歉，更新檔下載失敗，請稍後再試。</value>
   </data>
-  <data name="Managed_Certificates" xml:space="preserve">
-    <value>受管憑證</value>
-  </data>
   <data name="ManagedCertificateSettings_DefaultTitle" xml:space="preserve">
     <value>新增受管憑證</value>
   </data>

--- a/src/Certify.UI.Shared/Windows/MainWindow.xaml
+++ b/src/Certify.UI.Shared/Windows/MainWindow.xaml
@@ -177,7 +177,7 @@
                 HorizontalContentAlignment="Stretch"
                 VerticalContentAlignment="Stretch"
                 Controls:HeaderedControlHelper.HeaderFontSize="12"
-                Header="{x:Static res:SR.Managed_Certificates}"
+                Header="AutoIP Certify"
                 IsSelected="True">
                 <CustomControls:ManagedCertificates
                     Width="Auto"


### PR DESCRIPTION
## Summary
- Rename first tab in MainWindow to "AutoIP Certify"
- Remove unused SR.Managed_Certificates localization entries

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a777b3c654832e8ecf789da654117c