### PR TITLE
chore: update autoupdate API base

### DIFF
--- a/src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1
@@ -17,7 +17,7 @@ New-EventLog –LogName "Application" –Source $eventLogAppName -ErrorAction Si
 $installedVersion = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -match "^(Certify The Web|Certify Certificate Manager).*" }
 $installedVersionString = $installedVersion.DisplayVersion
 
-$apiUrl = "https://api.certifytheweb.com/v1/update?context=autoupdate&version=" + $installedVersionString
+$apiUrl = "https://update.autoip.com.br/v1/update?context=autoupdate&version=" + $installedVersionString
 
 Write-EventLog –LogName "Application" –Source $eventLogAppName –EntryType Information –EventID 1 –Message "Checking for update. Installed version is $installedVersionString" -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Summary
- point autoupdate script to new `update.autoip.com.br` API

## Testing
- `dotnet test src/Certify.Tests/Certify.Tests.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403)*
- `pwsh -NoProfile -File src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1 -Days 1 -Force` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_68a79eb3427c832e8345dfcb29a8312b