### PR TITLE
refactor: clarify update endpoint

### DIFF
--- a/src/Certify.Shared/Utils/Util.cs
+++ b/src/Certify.Shared/Utils/Util.cs
@@ -208,7 +208,9 @@ namespace Certify.Management
                 {
                     client.DefaultRequestHeaders.Add("User-Agent", Util.GetUserAgent());
 
-                    var response = await client.GetAsync(Models.API.Config.APIBaseURI + "update?version=" + appVersion);
+                    // https://update.autoip.com.br/v1/update?version={appVersion}
+                    var updateUri = new Uri(new Uri(Models.API.Config.APIBaseURI), $"update?version={appVersion}");
+                    var response = await client.GetAsync(updateUri);
                     if (response.IsSuccessStatusCode)
                     {
                         var json = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- use `Uri` to compose update check URL
- document new update service endpoint

## Testing
- `dotnet build src/Certify.Shared/Certify.Shared.Core.csproj` *(fails: dotnet: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a79f830994832e86549f3f44603348