### PR TITLE
docs: update API reference

### DIFF
--- a/src/Certify.Shared.Extensions/Scripts/Web.config/readme.txt
+++ b/src/Certify.Shared.Extensions/Scripts/Web.config/readme.txt
@@ -19,6 +19,6 @@ we cycle through a number of alternative web.config options and test each one. T
 http://<yourdomain>/.well-known/acme-challenge/configcheck
 
 If the local request fails (perhaps because the local server can't resolve itself via DNS etc) and if proxy API support is enabled, the app asks
-the https://api.certifytheweb.com server if it can access the resource.
+the https://update.autoip.com.br server if it can access the resource.
 
 


### PR DESCRIPTION
## Summary
- replace outdated api.certifytheweb.com reference with update.autoip.com.br in web.config readme

## Testing
- `dotnet test src/Certify.Tests/Certify.Tests.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a033b760832eaa29c05c3f3e0667