### PR TITLE
refactor: centralize API base URI usage

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Certify.Models.Config;
+using Certify.Models.API;
 using Certify.Models.Plugins;
 using Certify.Models.Providers;
 using Certify.Plugins;
@@ -15,7 +16,7 @@ namespace Certify.Providers.DNS.AutoIP
 
     public class DnsProviderAutoIP : DnsProviderBase, IDnsProvider
     {
-        private const string DEFAULT_API_ENDPOINT = "https://update.autoip.com.br/acme";
+        private static readonly string DEFAULT_API_ENDPOINT = new Uri(new Uri(Config.APIBaseURI), "../acme").ToString();
 
         private HttpClient _http;
         private ILog _log;
@@ -34,7 +35,7 @@ namespace Certify.Providers.DNS.AutoIP
             Id = "DNS01.API.AutoIP",
             Title = "AutoIP DNS API",
             Description = "Validates via AutoIP DNS API using token or user credentials.",
-            HelpUrl = "https://update.autoip.com.br/",
+            HelpUrl = new Uri(new Uri(Config.APIBaseURI), "../").ToString(),
             PropagationDelaySeconds = 60,
             ProviderParameters = new List<ProviderParameter>{
                 new ProviderParameter{ Key="apiendpoint", Name="API Endpoint", IsRequired=false, IsCredential=false, IsPassword=false, Value=DEFAULT_API_ENDPOINT },

--- a/src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1
@@ -1,4 +1,4 @@
-﻿param ([int]$Days=7, [switch]$Force)
+﻿param ([int]$Days=7, [switch]$Force, [string]$ApiBaseUri = "https://update.autoip.com.br/v1/")
 
 # Certify The Web - App Updater Script
 # Schedule this powershell script task using an Administrator account for automatic update N days after the last official release
@@ -17,7 +17,7 @@ New-EventLog –LogName "Application" –Source $eventLogAppName -ErrorAction Si
 $installedVersion = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -match "^(Certify The Web|Certify Certificate Manager).*" }
 $installedVersionString = $installedVersion.DisplayVersion
 
-$apiUrl = "https://update.autoip.com.br/v1/update?context=autoupdate&version=" + $installedVersionString
+$apiUrl = $ApiBaseUri + "update?context=autoupdate&version=" + $installedVersionString
 
 Write-EventLog –LogName "Application" –Source $eventLogAppName –EntryType Information –EventID 1 –Message "Checking for update. Installed version is $installedVersionString" -ErrorAction SilentlyContinue
 

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/UpdateCheckTest.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/UpdateCheckTest.cs
@@ -1,5 +1,6 @@
 using System;
 using Certify.Models;
+using Certify.Models.API;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Certify.Core.Tests.Unit
@@ -13,8 +14,9 @@ namespace Certify.Core.Tests.Unit
             var updateVersion = "2.0.1";
 
             // ensure update uri is constructed using the correct base url
-            var update = new Uri($"https://update.autoip.com.br/v1/update?version={updateVersion}");
-            Assert.AreEqual($"https://update.autoip.com.br/v1/update?version={updateVersion}", update.ToString());
+            var expected = new Uri(new Uri(Config.APIBaseURI), $"update?version={updateVersion}");
+            var update = expected;
+            Assert.AreEqual(expected.ToString(), update.ToString());
 
             var updateChecker = new Certify.Management.Util();
             var result = updateChecker.CheckForUpdates(updateVersion).Result;

--- a/src/Certify.UI.Shared/Windows/Registration.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/Registration.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Input;
 using Certify.Models;
+using Certify.Models.API;
 
 namespace Certify.UI.Windows
 {
@@ -95,7 +96,8 @@ namespace Certify.UI.Windows
                 catch (System.Net.Http.HttpRequestException exp)
                 {
                     Log?.Information("ValidateKey:" + exp.ToString());
-                    MessageBox.Show("Communication with the Certify The Web API failed. Check your system can communicate with https://update.autoip.com.br/v1/update using a web browser. \r\n\r\nIf your system is running an older version of Windows, check https://docs.certifytheweb.com for 'TLS Cipher', as updated registry settings may be required.");
+                    var updateUrl = Config.APIBaseURI + "update";
+                    MessageBox.Show($"Communication with the Certify The Web API failed. Check your system can communicate with {updateUrl} using a web browser. \r\n\r\nIf your system is running an older version of Windows, check https://docs.certifytheweb.com for 'TLS Cipher', as updated registry settings may be required.");
                 }
                 catch (Exception exp)
                 {


### PR DESCRIPTION
## Summary
- use Models.API.Config.APIBaseURI to build AutoIP DNS provider endpoint and help URLs
- reuse APIBaseURI in registration error messaging and update tests
- parameterize auto-update script with API base URI

## Testing
- `dotnet test src/Certify.Core.Service.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a18954ec832ebb107261ff885ba7