### PR TITLE
fix: correct API config reference

### DIFF
--- a/src/Certify.UI.Shared/Windows/Registration.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/Registration.xaml.cs
@@ -2,7 +2,7 @@
 using System.Windows;
 using System.Windows.Input;
 using Certify.Models;
-using Certify.Models.API;
+using APIConfig = Certify.Models.API.Config;
 
 namespace Certify.UI.Windows
 {
@@ -96,7 +96,7 @@ namespace Certify.UI.Windows
                 catch (System.Net.Http.HttpRequestException exp)
                 {
                     Log?.Information("ValidateKey:" + exp.ToString());
-                    var updateUrl = Config.APIBaseURI + "update";
+                    var updateUrl = APIConfig.APIBaseURI + "update";
                     MessageBox.Show($"Communication with the Certify The Web API failed. Check your system can communicate with {updateUrl} using a web browser. \r\n\r\nIf your system is running an older version of Windows, check https://docs.certifytheweb.com for 'TLS Cipher', as updated registry settings may be required.");
                 }
                 catch (Exception exp)


### PR DESCRIPTION
## Summary
- use correct API config reference in Registration dialog

## Testing
- `dotnet build src/Certify.UI.sln -c Release -p:EnableWindowsTargeting=true` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a3d8741c832eb38451c422055fd0