### PR TITLE
fix: add feature visibility converter resources

### DIFF
--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/AdvancedOptions.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/AdvancedOptions.xaml
@@ -8,7 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Certify.UI.Controls.ManagedCertificate"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:utils="clr-namespace:Certify.UI.Utils"
+    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
     d:DataContext="{d:DesignInstance Type=certifyui:ManagedCertificateViewModelDesign,
                                      IsDesignTimeCreatable=True}"
     Loaded="UserControl_Loaded"
@@ -22,6 +22,7 @@
             x:Key="NullVisibleConverter"
             NotNull="Collapsed"
             Null="Visible" />
+        <utils:FeatureVisibilityConverter x:Key="FeatureVisibilityConverter" />
     </UserControl.Resources>
     <ScrollViewer Margin="0,8,0,0" VerticalScrollBarVisibility="Auto">
         <DockPanel Margin="0,0,8,0" LastChildFill="False">

--- a/src/Certify.UI.Shared/Controls/Settings/CertificateAuthorities.xaml
+++ b/src/Certify.UI.Shared/Controls/Settings/CertificateAuthorities.xaml
@@ -5,12 +5,17 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:Certify.UI.Controls.Settings"
+    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     d:DesignHeight="450"
     d:DesignWidth="800"
     Loaded="UserControl_Loaded"
     mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <utils:FeatureVisibilityConverter x:Key="FeatureVisibilityConverter" />
+    </UserControl.Resources>
 
     <!--  Certificate Authority Preference  -->
     <StackPanel Orientation="Vertical">

--- a/src/Certify.UI.Shared/Controls/Settings/General.xaml
+++ b/src/Certify.UI.Shared/Controls/Settings/General.xaml
@@ -7,6 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:Certify.UI.Controls.Settings"
+    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     d:DesignHeight="420.042"
@@ -14,7 +15,9 @@
     Loaded="UserControl_Loaded"
     mc:Ignorable="d">
 
-    <UserControl.Resources />
+    <UserControl.Resources>
+        <utils:FeatureVisibilityConverter x:Key="FeatureVisibilityConverter" />
+    </UserControl.Resources>
     <ScrollViewer Margin="0,0,0,-113" VerticalScrollBarVisibility="Auto">
         <DockPanel Margin="0,8,0,8">
             <TabControl

--- a/src/Certify.UI.Shared/Windows/MainWindow.xaml
+++ b/src/Certify.UI.Shared/Windows/MainWindow.xaml
@@ -8,6 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:Certify.UI"
+    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     Title="{x:Static res:ConfigResources.AppName}"
@@ -24,6 +25,10 @@
     WindowButtonCommandsOverlayBehavior="Never"
     WindowTransitionsEnabled="False"
     mc:Ignorable="d">
+
+    <Controls:MetroWindow.Resources>
+        <utils:FeatureVisibilityConverter x:Key="FeatureVisibilityConverter" />
+    </Controls:MetroWindow.Resources>
 
     <Grid>
         <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- add FeatureVisibilityConverter resource in MainWindow and settings/advanced views
- ensure utils namespace references Certify.UI.Shared assembly

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a46f4b10832eac08c1192dce8761