### PR TITLE
Fix XAML converter references

### DIFF
--- a/src/Certify.UI.Shared/Controls/Settings/General.xaml
+++ b/src/Certify.UI.Shared/Controls/Settings/General.xaml
@@ -7,7 +7,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:Certify.UI.Controls.Settings"
-    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
+    xmlns:utils="clr-namespace:Certify.UI.Utils"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     d:DesignHeight="420.042"
@@ -16,6 +16,7 @@
     mc:Ignorable="d">
 
     <UserControl.Resources>
+        <utils:InverseBooleanConverter x:Key="InvBoolConverter" />
         <utils:FeatureVisibilityConverter x:Key="FeatureVisibilityConverter" />
     </UserControl.Resources>
     <ScrollViewer Margin="0,0,0,-113" VerticalScrollBarVisibility="Auto">

--- a/src/Certify.UI/App.xaml
+++ b/src/Certify.UI/App.xaml
@@ -80,6 +80,7 @@
             <DataTemplate x:Key="ProviderHiddenParameter" />
 
             <!--  standard converters  -->
+            <utils:InverseBooleanConverter x:Key="InvBoolConverter" />
             <utils:FeatureVisibilityConverter x:Key="FeatureVisibilityConverter" />
             <utils:FeatureBooleanConverter x:Key="FeatureBooleanConverter" />
             <utils:NullValueConverter x:Key="NullValueConverter" />


### PR DESCRIPTION
## Summary
- add inverse boolean converter resources to App.xaml and General.xaml
- correct utils namespace for shared settings control

## Testing
- `dotnet build src/Certify.UI.sln -p:EnableWindowsTargeting=true` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cd8a9d24832e9cc212dc52c36378