### PR TITLE
Ensure BooleanConverters is compiled and fix utils namespace

### DIFF
--- a/src/Certify.UI.Shared/Certify.UI.Shared.csproj
+++ b/src/Certify.UI.Shared/Certify.UI.Shared.csproj
@@ -67,6 +67,9 @@
     <ItemGroup>
         <SplashScreen Include="Assets\Images\splashscreen.png" />
     </ItemGroup>
+    <ItemGroup>
+        <Compile Update="Utils/BooleanConverters.cs" />
+    </ItemGroup>
 
     <ItemGroup>
         <Page Update="Windows\EditDataStoreConnection.xaml">

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/AdvancedOptions.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/AdvancedOptions.xaml
@@ -8,7 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Certify.UI.Controls.ManagedCertificate"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
+    xmlns:utils="clr-namespace:Certify.UI.Utils"
     d:DataContext="{d:DesignInstance Type=certifyui:ManagedCertificateViewModelDesign,
                                      IsDesignTimeCreatable=True}"
     Loaded="UserControl_Loaded"

--- a/src/Certify.UI.Shared/Controls/Settings/CertificateAuthorities.xaml
+++ b/src/Certify.UI.Shared/Controls/Settings/CertificateAuthorities.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:Certify.UI.Controls.Settings"
-    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
+    xmlns:utils="clr-namespace:Certify.UI.Utils"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     d:DesignHeight="450"

--- a/src/Certify.UI.Shared/Windows/DataStoreConnections.xaml
+++ b/src/Certify.UI.Shared/Windows/DataStoreConnections.xaml
@@ -7,7 +7,7 @@
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:Certify.UI.Windows"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
+    xmlns:utils="clr-namespace:Certify.UI.Utils"
     Title="Data Store Connections"
     Width="450"
     Height="390"

--- a/src/Certify.UI.Shared/Windows/MainWindow.xaml
+++ b/src/Certify.UI.Shared/Windows/MainWindow.xaml
@@ -8,7 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:Certify.UI"
-    xmlns:utils="clr-namespace:Certify.UI.Utils;assembly=Certify.UI.Shared"
+    xmlns:utils="clr-namespace:Certify.UI.Utils"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     Title="{x:Static res:ConfigResources.AppName}"


### PR DESCRIPTION
## Summary
- ensure BooleanConverters.cs is explicitly compiled in shared project
- standardize utils namespace usage across shared XAML files

## Testing
- `dotnet clean Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cfbc4098832e8a2014e44c239866