### PR TITLE
feat: allow custom certificate export directory

### DIFF
--- a/src/Certify.Models/Config/CertRequestConfig.cs
+++ b/src/Certify.Models/Config/CertRequestConfig.cs
@@ -230,9 +230,14 @@ namespace Certify.Models
         public string? CSRKeyAlg { get; set; }
 
         /// <summary>
-        /// Deployment site options (single/all etc) 
+        /// Deployment site options (single/all etc)
         /// </summary>
         public DeploymentOption DeploymentSiteOption { get; set; } = DeploymentOption.SingleSite;
+
+        /// <summary>
+        /// Optional custom directory to store exported certificate files when using no deployment.
+        /// </summary>
+        public string? CustomCertificateDirectory { get; set; }
 
         /// <summary>
         /// Binding options: Add/Update or Update 

--- a/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
+++ b/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
@@ -1661,7 +1661,7 @@ namespace Certify.Providers.ACME.Anvil
             {
                 if (DefaultCertificateFormat == "pfx" || DefaultCertificateFormat == "all")
                 {
-                    primaryCertOutputFile = ExportFullCertPFX(certFriendlyName, pwd, csrKey, certificateChain, certId, primaryIdentifierAsPath, includeCleanup: true, useModernKeyAlgorithms: useModernPFXBuildAlgs, itemLog: log);
+                    primaryCertOutputFile = ExportFullCertPFX(certFriendlyName, pwd, csrKey, certificateChain, certId, primaryIdentifierAsPath, config, includeCleanup: true, useModernKeyAlgorithms: useModernPFXBuildAlgs, itemLog: log);
                 }
             }
             catch (Exception ex)
@@ -1951,21 +1951,38 @@ namespace Certify.Providers.ACME.Anvil
             }
         }
 
-        private string ExportFullCertPFX(string certFriendlyName, string pwd, IKey csrKey, CertificateChain certificateChain, string certId, string primaryIdentifierPath, bool includeCleanup = true, bool useModernKeyAlgorithms = false, ILog itemLog = null)
+        private string ExportFullCertPFX(string certFriendlyName, string pwd, IKey csrKey, CertificateChain certificateChain, string certId, string primaryIdentifierPath, CertRequestConfig requestConfig, bool includeCleanup = true, bool useModernKeyAlgorithms = false, ILog itemLog = null)
         {
-            var storePath = Path.GetFullPath(Path.Combine(new string[] { _providerSettings.ServiceSettingsBasePath, "assets", primaryIdentifierPath }));
+            var storePath = string.Empty;
 
-            if (!System.IO.Directory.Exists(storePath))
+            if (requestConfig.DeploymentSiteOption == DeploymentOption.NoDeployment && !string.IsNullOrEmpty(requestConfig.CustomCertificateDirectory))
             {
-                System.IO.Directory.CreateDirectory(storePath);
+                storePath = Path.GetFullPath(requestConfig.CustomCertificateDirectory);
             }
             else
             {
-                // attempt old pfx asset cleanup
-                if (includeCleanup)
+                storePath = Path.GetFullPath(Path.Combine(new string[] { _providerSettings.ServiceSettingsBasePath, "assets", primaryIdentifierPath }));
+            }
+
+            try
+            {
+                if (!System.IO.Directory.Exists(storePath))
                 {
-                    PerformAssetCleanup(storePath);
+                    System.IO.Directory.CreateDirectory(storePath);
                 }
+                else
+                {
+                    // attempt old pfx asset cleanup
+                    if (includeCleanup && storePath.StartsWith(_providerSettings.ServiceSettingsBasePath))
+                    {
+                        PerformAssetCleanup(storePath);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                itemLog?.Error(ex, $"Failed to access certificate export directory: {storePath}");
+                throw;
             }
 
             var pfxFile = certId + ".pfx";

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/AdvancedOptions.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/AdvancedOptions.xaml
@@ -450,6 +450,21 @@
                                 Margin="0,8,32,0"
                                 HorizontalAlignment="Left"
                                 Style="{StaticResource Instructions}"
+                                Text="Custom Export Directory:" />
+                            <TextBox
+                                MaxWidth="500"
+                                Margin="0,8,0,0"
+                                HorizontalAlignment="Left"
+                                IsReadOnly="True"
+                                Text="{Binding SelectedItem.RequestConfig.CustomCertificateDirectory}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+
+                        <StackPanel DockPanel.Dock="Top">
+                            <TextBlock
+                                Margin="0,8,32,0"
+                                HorizontalAlignment="Left"
+                                Style="{StaticResource Instructions}"
                                 Text="Current Certificate file path (changes after every renewal):" />
                             <TextBox
                                 x:Name="CertPath"

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/Deployment.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/Deployment.xaml
@@ -93,7 +93,14 @@
                         </Style.Triggers>
                     </Style>
                 </DockPanel.Style>
-                <TextBlock Style="{StaticResource Instructions}" Text="Certificate will be saved to disk but will not be imported automatically into the Certificate Store." />
+                <StackPanel>
+                    <TextBlock Style="{StaticResource Instructions}" Text="Certificate will be saved to disk but will not be imported automatically into the Certificate Store." />
+                    <StackPanel Margin="0,8,0,0" Orientation="Horizontal">
+                        <Label Width="160" Content="Export Directory" />
+                        <TextBox Width="225" Text="{Binding SelectedItem.RequestConfig.CustomCertificateDirectory}" />
+                        <Button Margin="4,0,0,0" Click="CustomCertDirBrowse_Click" Content="{x:Static Resources:SR.ManagedCertificateSettings_BrowseFolder}" />
+                    </StackPanel>
+                </StackPanel>
             </DockPanel>
 
             <DockPanel x:Name="AdvancedBindingOptions" DockPanel.Dock="Top">

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/Deployment.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/Deployment.xaml.cs
@@ -2,6 +2,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using Certify.UI.Windows;
+using WinForms = System.Windows.Forms;
 
 namespace Certify.UI.Controls.ManagedCertificate
 {
@@ -74,6 +75,25 @@ namespace Certify.UI.Controls.ManagedCertificate
             // if deployment mode changes, apply defaults for the mode
             ItemViewModel.SelectedItem?.RequestConfig?.ApplyDeploymentOptionDefaults();
 
+        }
+
+        private void CustomCertDirBrowse_Click(object sender, RoutedEventArgs e)
+        {
+            var config = ItemViewModel.SelectedItem?.RequestConfig;
+            if (config == null)
+            {
+                return;
+            }
+
+            var dialog = new WinForms.FolderBrowserDialog()
+            {
+                SelectedPath = config.CustomCertificateDirectory
+            };
+
+            if (dialog.ShowDialog() == WinForms.DialogResult.OK)
+            {
+                config.CustomCertificateDirectory = dialog.SelectedPath;
+            }
         }
 
         private void AddDeploymentTask_Click(object sender, System.Windows.RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- add CustomCertificateDirectory to certificate request config
- enable directory selection for no deployment mode
- use custom export path when saving certificates

## Testing
- `dotnet build src/Certify.Core.Service.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e94d32ac832e8388c8c27b2ba736