### PR TITLE
Set default UI culture to pt-BR and apply on first run

### DIFF
--- a/src/Certify.UI.Shared/ICertifyApp.cs
+++ b/src/Certify.UI.Shared/ICertifyApp.cs
@@ -81,6 +81,11 @@ namespace Certify.UI.Shared
             {
                 ChangeCulture(mainViewModel.UISettings.PreferredUICulture, false);
             }
+            else
+            {
+                mainViewModel.UISettings = new Settings.UISettings();
+                ChangeCulture("pt-BR", false);
+            }
 
             // setup notifications toast handler
             return new Notifier(cfg =>

--- a/src/Certify.UI.Shared/Settings/UISettings.cs
+++ b/src/Certify.UI.Shared/Settings/UISettings.cs
@@ -17,7 +17,7 @@ namespace Certify.UI.Settings
 
         public double? Scaling { get; set; } = 1;
 
-        public string PreferredUICulture { get; set; } = "en-US";
+        public string PreferredUICulture { get; set; } = "pt-BR";
 
         public string CommunityMode { get; set; }
 


### PR DESCRIPTION
## Summary
- default UI settings to Portuguese (pt-BR)
- initialize UI settings and apply pt-BR culture when none exists

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8db39e774832eb8c14a65a809b6f8