### PR TITLE
feat: add Brazilian Portuguese UI culture option

### DIFF
--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Settings.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Settings.cs
@@ -61,6 +61,7 @@ namespace Certify.UI.ViewModel
             {"es-ES","Spanish/Español"},
             {"ja-JP","Japanese/日本語"},
             {"nb-NO","Norwegian/Bokmål"},
+            {"pt-BR","Portuguese (Brazil)/Português (Brasil)"},
             {"tr-TR","Turkish/Türkçe"},
             {"zh-Hans","Chinese (Simplified)/中文 (简体)"},
             {"zh-Hant","Chinese (Traditional)/中文 (繁體)"}


### PR DESCRIPTION
## Summary
- support Brazilian Portuguese translations in UI culture dictionary

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dbe132a8832eaa535cf379d003ee