### PR TITLE
feat: add Brazilian Portuguese localization

### DIFF
--- a/src/Certify.Locales/Certify.Locales.csproj
+++ b/src/Certify.Locales/Certify.Locales.csproj
@@ -28,6 +28,9 @@
         <EmbeddedResource Update="ConfigResources.nb-NO.resx">
             <DependentUpon>ConfigResources.resx</DependentUpon>
         </EmbeddedResource>
+        <EmbeddedResource Update="ConfigResources.pt-BR.resx">
+            <DependentUpon>ConfigResources.resx</DependentUpon>
+        </EmbeddedResource>
         <EmbeddedResource Update="ConfigResources.tr-TR.resx">
             <DependentUpon>ConfigResources.resx</DependentUpon>
         </EmbeddedResource>
@@ -45,6 +48,9 @@
             <DependentUpon>CoreSR.resx</DependentUpon>
         </EmbeddedResource>
         <EmbeddedResource Update="CoreSR.nb-NO.resx">
+            <DependentUpon>CoreSR.resx</DependentUpon>
+        </EmbeddedResource>
+        <EmbeddedResource Update="CoreSR.pt-BR.resx">
             <DependentUpon>CoreSR.resx</DependentUpon>
         </EmbeddedResource>
         <EmbeddedResource Update="CoreSR.tr-TR.resx">
@@ -73,6 +79,9 @@
             <DependentUpon>SR.resx</DependentUpon>
         </EmbeddedResource>
         <EmbeddedResource Update="SR.nb-NO.resx">
+            <DependentUpon>SR.resx</DependentUpon>
+        </EmbeddedResource>
+        <EmbeddedResource Update="SR.pt-BR.resx">
             <DependentUpon>SR.resx</DependentUpon>
         </EmbeddedResource>
         <EmbeddedResource Update="SR.tr-TR.resx">

--- a/src/Certify.Locales/ConfigResources.pt-BR.resx
+++ b/src/Certify.Locales/ConfigResources.pt-BR.resx
@@ -1,0 +1,70 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+
+  <data name="UpdateCheckLatestVersion" xml:space="preserve">
+    <value>Você está usando a versão mais recente.</value>
+  </data>
+  <data name="BetaWarning" xml:space="preserve">
+    <value>Aviso: este software é uma versão preliminar para fins de teste e feedback. Você deve esperar erros. Não confie neste software para sites de produção importantes.</value>
+  </data>
+
+</root>

--- a/src/Certify.Locales/CoreSR.pt-BR.resx
+++ b/src/Certify.Locales/CoreSR.pt-BR.resx
@@ -1,0 +1,145 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	
+	<xs:schema id="root">
+		<xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+		<xs:element name="root" ns1:IsDataSet="true">
+			<xs:complexType>
+				<xs:choice maxOccurs="unbounded">
+					<xs:element name="metadata">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="value" type="xsd:string" minOccurs="0" />
+							</xs:sequence>
+							<xs:attribute name="name" use="required" type="xsd:string" />
+							<xs:attribute name="type" type="xsd:string" />
+							<xs:attribute name="mimetype" type="xsd:string" />
+							<xs:attribute ref="xml:space" />
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="assembly">
+						<xs:complexType>
+							<xs:attribute name="alias" type="xsd:string" />
+							<xs:attribute name="name" type="xsd:string" />
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="data">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+								<xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+							</xs:sequence>
+							<xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+							<xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+							<xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+							<xs:attribute ref="xml:space" />
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="resheader">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+							</xs:sequence>
+							<xs:attribute name="name" type="xsd:string" use="required" />
+						</xs:complexType>
+					</xs:element>
+				</xs:choice>
+			</xs:complexType>
+		</xs:element>
+	</xs:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="CertifyManager_RegisterDomainIdentity" xml:space="preserve">
+    <value>Registro de Identificadores de Domínio</value>
+  </data>
+	<data name="CertifyManager_DomainValidationFailed" xml:space="preserve">
+    <value>Falha na validação do domínio: {0}
+{1}</value>
+  </data>
+	<data name="CertifyManager_DomainValidationCompleted" xml:space="preserve">
+    <value>Validação de domínio concluída: {0}</value>
+  </data>
+	<data name="Finish" xml:space="preserve">
+    <value>Concluir</value>
+  </data>
+	<data name="CertifyManager_CertificateInstallFailed" xml:space="preserve">
+    <value>Ocorreu um erro ao instalar o certificado. O arquivo de certificado pode não ser válido: {0}</value>
+  </data>
+	<data name="CertificateRequestWasAbortedByPSScript" xml:space="preserve">
+    <value>A solicitação de certificado foi abortada por script de PS</value>
+  </data>
+	<data name="CertifyManager_AutomateConfigurationCheckFailed_HTTP" xml:space="preserve">
+    <value>As verificações de configuração automatizadas falharam. As autorizações não poderão ser concluídas. Verifique se você tem vínculos HTTP para seu site e certifique-se de que é possível navegar para http://{0}/.well-known/acme-challenge/configcheck antes de continuar.</value>
+  </data>
+	<data name="CertifyManager_AutoBinding" xml:space="preserve">
+    <value>Executando vinculação automática de certificado</value>
+  </data>
+	<data name="CertifyManager_CertificateCreatedForBinding" xml:space="preserve">
+    <value>Certificado criado pronto para ligação manual: {0}</value>
+  </data>
+	<data name="CertifyManager_CompleteRequest" xml:space="preserve">
+    <value>Solicitação de certificado concluída</value>
+  </data>
+	<data name="CertifyManager_CompleteRequestAndUpdateBinding" xml:space="preserve">
+    <value>Solicitação de certificado e atualização automática de vínculos concluída (IIS)</value>
+  </data>
+	<data name="CertifyManager_DomainValidationSkipVerifed" xml:space="preserve">
+    <value>O domínio já está autorizado, ignorando a verificação: {0}</value>
+  </data>
+	<data name="ManagedCertificateType_Manual" xml:space="preserve">
+    <value>Certificado SSL manual via ACME CA</value>
+  </data>
+	<data name="ManagedCertificateType_LocalIIS" xml:space="preserve">
+    <value>Certificado SSL IIS local via ACME CA</value>
+  </data>
+	<data name="CertifyManager_AutomateConfigurationCheckFailed_SNI" xml:space="preserve">
+    <value>As verificações de configuração automatizadas falharam. As autorizações não poderão ser concluídas. Verifique se você tem vínculos https de SNI para seu site
+(por exemplo: '0123456789ABCDEF0123456789ABCDEF.0123456789ABCDEF0123456789ABCDEF.acme.invalid') antes de continuar.</value>
+  </data>
+	<data name="CertifyManager_CertificateInstalledAndBindingUpdated" xml:space="preserve">
+    <value>Certificado instalado e vínculos SSL atualizados para {0}</value>
+  </data>
+	<data name="CertifyManager_FailedPrerequisiteCheck" xml:space="preserve">
+    <value>Verificação de configuração de pré-requisitos falhou ({0})</value>
+  </data>
+	<data name="CertifyManager_LetsEncryptServiceTimeout" xml:space="preserve">
+    <value>O serviço ACME CA não emitiu um certificado válido no tempo permitido. {0}</value>
+  </data>
+	<data name="CertifyManager_PerformingConfigTests" xml:space="preserve">
+    <value>Executando testes de configuração</value>
+  </data>
+	<data name="CertifyManager_RegisteringAndValidatingX0" xml:space="preserve">
+    <value>Registrando e validando {0}</value>
+  </data>
+	<data name="CertifyManager_RequestCertificate" xml:space="preserve">
+    <value>Solicitando certificado via CA</value>
+  </data>
+	<data name="CertifyManager_ReqestValidationFromLetsEncrypt" xml:space="preserve">
+    <value>Solicitando validação: {0}</value>
+  </data>
+	<data name="CertifyManager_RequestFailed" xml:space="preserve">
+    <value>{0}: solicitação falhou - {1} {2}</value>
+  </data>
+	<data name="CertifyManager_SiteStopped" xml:space="preserve">
+    <value>Site parado (ou ausente), a renovação foi omitida porque a validação do domínio não pôde ser realizada.</value>
+  </data>
+	<data name="CertifyManager_SkipRenewalOk" xml:space="preserve">
+    <value>Pulando a renovação, o certificado existente ainda é válido.</value>
+  </data>
+	<data name="CertifyManager_ValidationForChallengeNotSuccess" xml:space="preserve">
+    <value>A validação dos desafios necessários não foi concluída com êxito. {0}</value>
+  </data>
+	<data name="CertifyManager_RenewalOnHold" xml:space="preserve">
+		<value>Renovações anteriores falharam: {0}. A renovação será tentada novamente dentro de 48 horas.</value>
+	</data>
+</root>

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -1,0 +1,597 @@
+<?xml version='1.0' encoding='utf-8'?>
+<root xmlns:ns1="urn:schemas-microsoft-com:xml-msdata" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  
+  <xs:schema id="root">
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xs:element name="root" ns1:IsDataSet="true">
+      <xs:complexType>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element name="metadata">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" />
+              </xs:sequence>
+              <xs:attribute name="name" use="required" type="xsd:string" />
+              <xs:attribute name="type" type="xsd:string" />
+              <xs:attribute name="mimetype" type="xsd:string" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="assembly">
+            <xs:complexType>
+              <xs:attribute name="alias" type="xsd:string" />
+              <xs:attribute name="name" type="xsd:string" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="data">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+                <xs:element name="comment" type="xsd:string" minOccurs="0" ns1:Ordinal="2" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" ns1:Ordinal="1" />
+              <xs:attribute name="type" type="xsd:string" ns1:Ordinal="3" />
+              <xs:attribute name="mimetype" type="xsd:string" ns1:Ordinal="4" />
+              <xs:attribute ref="xml:space" />
+            </xs:complexType>
+          </xs:element>
+          <xs:element name="resheader">
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="value" type="xsd:string" minOccurs="0" ns1:Ordinal="1" />
+              </xs:sequence>
+              <xs:attribute name="name" type="xsd:string" use="required" />
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
+      </xs:complexType>
+    </xs:element>
+  </xs:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Registration" xml:space="preserve">
+    <value>Registro</value>
+  </data>
+  <data name="RegistrationEmailAddress" xml:space="preserve">
+    <value>E-mail registrado</value>
+  </data>
+  <data name="LicenseKey" xml:space="preserve">
+    <value>Chave de licença</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="ValidateKey" xml:space="preserve">
+    <value>Validar chave</value>
+  </data>
+  <data name="New_Certificate" xml:space="preserve">
+    <value>Novo certificado</value>
+  </data>
+  <data name="Renew_All" xml:space="preserve">
+    <value>Renovar tudo</value>
+  </data>
+  <data name="Configure_Auto_Renew" xml:space="preserve">
+    <value>Configurar renovação automática</value>
+  </data>
+  <data name="Update_Available" xml:space="preserve">
+    <value>Atualização disponível</value>
+  </data>
+  <data name="Managed_Sites" xml:space="preserve">
+    <value>Sites</value>
+  </data>
+  <data name="In_Progress" xml:space="preserve">
+    <value>Em andamento</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Configurações</value>
+  </data>
+  <data name="About" xml:space="preserve">
+    <value>Sobre</value>
+  </data>
+  <data name="Email_Address" xml:space="preserve">
+    <value>E-mail</value>
+  </data>
+  <data name="Account_Edit_AgreeConfirm" xml:space="preserve">
+    <value>Sim, concordo</value>
+  </data>
+  <data name="Register_Contact" xml:space="preserve">
+    <value>Registrar contato</value>
+  </data>
+  <data name="Account_Edit_Intro" xml:space="preserve">
+    <value>Para solicitar certificados, você deve se registrar em cada Autoridade de Certificação que desejar utilizar.</value>
+  </data>
+  <data name="Account_Edit_Intro2" xml:space="preserve">
+    <value>O endereço de e-mail fornecido pode ser usado para notificá-lo sobre a próxima renovação de certificados, se necessário. Endereços de e-mail inválidos serão rejeitados pela Autoridade de Certificação.</value>
+  </data>
+  <data name="Send_Feedback" xml:space="preserve">
+    <value>Enviar comentários</value>
+  </data>
+  <data name="Send_Feedback_Tip" xml:space="preserve">
+    <value>Sua opinião é importante para nós. Por favor, diga-nos como podemos melhorar.</value>
+  </data>
+  <data name="Send_Feedback_Quest" xml:space="preserve">
+    <value>Você tem alguma sugestão?</value>
+  </data>
+  <data name="Send_Feedback_Email" xml:space="preserve">
+    <value>Seu e-mail (se desejar uma resposta):</value>
+  </data>
+  <data name="Send" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+  <data name="ImportDlg_Title" xml:space="preserve">
+    <value>Certify - Importar</value>
+  </data>
+  <data name="ImportDlg_OpTitle" xml:space="preserve">
+    <value>Importar sites gerenciados</value>
+  </data>
+  <data name="ImportDlg_OpComment" xml:space="preserve">
+    <value>Você está atualizando de uma versão anterior do Certify. Isso criará novos Sites Gerenciados que você poderá editar para ajustar a configuração de renovação, etc.</value>
+  </data>
+  <data name="ImportDlg_Merge" xml:space="preserve">
+    <value>Combinar múltiplos domínios/certificados por site em um Site Gerenciado</value>
+  </data>
+  <data name="ImportDlg_Skip" xml:space="preserve">
+    <value>Pular importação</value>
+  </data>
+  <data name="Import" xml:space="preserve">
+    <value>Importar</value>
+  </data>
+  <data name="Send_Feedback_Exception" xml:space="preserve">
+    <value>Opa! Algo deu errado. Por favor, conte-nos mais detalhes.</value>
+  </data>
+  <data name="Send_Feedback_Success" xml:space="preserve">
+    <value>Obrigado, seus comentários foram enviados.</value>
+  </data>
+  <data name="Send_Feedback_Error" xml:space="preserve">
+    <value>Desculpe, ocorreu um problema ao enviar seus comentários.</value>
+  </data>
+  <data name="New_Contact_EmailError" xml:space="preserve">
+    <value>Houve um problema ao registrar-se com a Autoridade de Certificação usando este e-mail. Verifique se o e-mail é válido e se este computador tem uma conexão aberta com a Internet (é necessário HTTPS de saída para as chamadas da API).</value>
+  </data>
+  <data name="Account_Edit_AgreeConditions" xml:space="preserve">
+    <value>Para continuar, confirme que aceita os termos e condições atuais desta Autoridade de Certificação.</value>
+  </data>
+  <data name="Registration_NeedEmail" xml:space="preserve">
+    <value>Insira o e-mail que você usou ao registrar sua chave.</value>
+  </data>
+  <data name="Registration_NeedKey" xml:space="preserve">
+    <value>Por favor, insira sua chave de licença.</value>
+  </data>
+  <data name="Registration_KeyValidationError" xml:space="preserve">
+    <value>Ocorreu um problema ao tentar validar sua chave de licença. Por favor, tente novamente ou entre em contato conosco.</value>
+  </data>
+  <data name="Registration_UnableToVerify" xml:space="preserve">
+    <value>Houve um problema ao iniciar o processo de validação da licença.</value>
+  </data>
+  <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
+    <value>A tarefa de renovação automática já está configurada. Se necessário, você pode alterar a conta de usuário administrador usada para executar a tarefa.</value>
+  </data>
+  <data name="ScheduledTaskConfig_FailedToCreateTask" xml:space="preserve">
+    <value>Erro ao criar a tarefa agendada com as credenciais fornecidas</value>
+  </data>
+  <data name="ScheduledTaskConfig_TaskCreated" xml:space="preserve">
+    <value>Tarefa agendada criada</value>
+  </data>
+  <data name="ScheduledTaskConfig_PleaseProvideCredential" xml:space="preserve">
+    <value>Forneça o nome de usuário e a senha de um usuário com nível de administrador.</value>
+  </data>
+  <data name="ScheduledTaskConfig_WindowTitle" xml:space="preserve">
+    <value>Configurar renovação automática</value>
+  </data>
+  <data name="ScheduledTaskConfig_UserNameLabel" xml:space="preserve">
+    <value>Usuário (DOMÍNIO\Usuário)</value>
+  </data>
+  <data name="ScheduledTaskConfig_Tip" xml:space="preserve">
+    <value>Para realizar a renovação automática de certificados, o Certify criará uma tarefa no Agendador de Tarefas do Windows. Essa tarefa deve ser executada como um usuário com nível de Administrador para realizar tarefas de administração de certificados e do IIS.</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Senha</value>
+  </data>
+  <data name="AboutControl_TrialDetailLabel" xml:space="preserve">
+    <value>Esta versão é gratuita para avaliação e gerenciará um número limitado de certificados. Para remover essa limitação, compre uma chave de registro em https://certifytheweb.com/register. Usuários registrados podem obter suporte enviando um e-mail para support@certifytheweb.com</value>
+  </data>
+  <data name="AboutControl_RegistrationTypeLabel" xml:space="preserve">
+    <value>Não registrado</value>
+  </data>
+  <data name="AboutControl_CheckForUpdateButton" xml:space="preserve">
+    <value>Procurar atualizações...</value>
+  </data>
+  <data name="AboutControl_EnterKey" xml:space="preserve">
+    <value>Inserir chave...</value>
+  </data>
+  <data name="AboutControl_SendFeedback" xml:space="preserve">
+    <value>Enviar comentários</value>
+  </data>
+  <data name="UpdateCheckLatestVersion" xml:space="preserve">
+    <value>Você está usando a versão mais recente.</value>
+  </data>
+  <data name="ManagedCertificates_Filter" xml:space="preserve">
+    <value>Filtrar...</value>
+  </data>
+  <data name="ManagedCertificates_NoItemSelectedTip" xml:space="preserve">
+    <value>Selecione um Site Gerenciado ou escolha Novo certificado para começar.</value>
+  </data>
+  <data name="ManagedCertificates_UnsavedWarning" xml:space="preserve">
+    <value>Existem alterações não salvas no site selecionado. Descartar as alterações?</value>
+  </data>
+  <data name="ProgressMonitor_NoProgress" xml:space="preserve">
+    <value>Não há solicitações em andamento.</value>
+  </data>
+  <data name="Settings_PrimaryContact" xml:space="preserve">
+    <value>Contato principal:</value>
+  </data>
+  <data name="Settings_AutoRenewalInterval" xml:space="preserve">
+    <value>Intervalo de renovação automática (dias)</value>
+  </data>
+  <data name="Settings_AutoRenewalRequestLimit" xml:space="preserve">
+    <value>Número máximo de solicitações de renovação automática por sessão (0 = ilimitado)</value>
+  </data>
+  <data name="Settings_CheckUpdates" xml:space="preserve">
+    <value>Verificar atualizações automaticamente</value>
+  </data>
+  <data name="Settings_EnableTelemetry" xml:space="preserve">
+    <value>Habilitar telemetria do aplicativo (relatórios de uso de recursos)</value>
+  </data>
+  <data name="Settings_EnableProxyApiForDomainConfig" xml:space="preserve">
+    <value>Habilitar proxy de API para as verificações de configuração de domínio</value>
+  </data>
+  <data name="Settings_IgnoreStoppedSites" xml:space="preserve">
+    <value>Ignorar sites IIS parados para novos certificados e renovações</value>
+  </data>
+  <data name="Settings_EnableDnsValidation" xml:space="preserve">
+    <value>Habilitar verificações de validação de DNS (Resolução, CAA, DNSSEC)</value>
+  </data>
+  <data name="SaveChanges" xml:space="preserve">
+    <value>Salvar alterações</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Salvar</value>
+  </data>
+  <data name="DiscardChanges" xml:space="preserve">
+    <value>Descartar alterações</value>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Excluir</value>
+  </data>
+  <data name="ManagedCertificateSettings_RequestCertificate" xml:space="preserve">
+    <value>Solicitar certificado</value>
+  </data>
+  <data name="ManagedCertificateSettings_EnableAutoRenewal" xml:space="preserve">
+    <value>Habilitar renovação automática</value>
+  </data>
+  <data name="ManagedCertificateSettings_NotifyPrimaryContactOnRenewalFailure" xml:space="preserve">
+    <value>Notificar o contato principal sobre a falha de renovação</value>
+  </data>
+  <data name="ManagedCertificateSettings_NoHostNameBindingWarning" xml:space="preserve">
+    <value>É necessário pelo menos um nome de host completo (por exemplo, 'github.com') ou curinga (por exemplo, '*.github.com') para criar um certificado.</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
+    <value>Opções</value>
+  </data>
+  <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
+    <value>Selecione o site IIS:</value>
+  </data>
+  <data name="ManagedCertificateSettings_DisplayName" xml:space="preserve">
+    <value>Nome de exibição:</value>
+  </data>
+  <data name="ManagedCertificateSettings_DomainIncluded" xml:space="preserve">
+    <value>Os seguintes domínios selecionados serão incluídos como uma única solicitação de certificado. O serviço Let's Encrypt deve conseguir acessar todos esses domínios pela porta 80 (para desafios HTTP) ou pela porta 443 (para desafios TLS-SNI) para que o processo de certificação funcione.</value>
+  </data>
+  <data name="ManagedCertificateSettings_SelectDomain" xml:space="preserve">
+    <value>Domínios e subdomínios a incluir:</value>
+  </data>
+  <data name="SelectAll" xml:space="preserve">
+    <value>Selecionar tudo</value>
+  </data>
+  <data name="ManagedCertificateSettings_SelectNone" xml:space="preserve">
+    <value>Limpar seleção</value>
+  </data>
+  <data name="ManagedCertificateSettings_Primary" xml:space="preserve">
+    <value>Primário</value>
+  </data>
+  <data name="ManagedCertificateSettings_Include" xml:space="preserve">
+    <value>Incluir</value>
+  </data>
+  <data name="ManagedCertificateSettings_Domain" xml:space="preserve">
+    <value>Domínio</value>
+  </data>
+  <data name="Advanced" xml:space="preserve">
+    <value>Avançado</value>
+  </data>
+  <data name="ManagedCertificateSettings_ChallengeTypes" xml:space="preserve">
+    <value>Tipo de desafio:</value>
+  </data>
+  <data name="ManagedCertificateSettings_WebsiteRoot" xml:space="preserve">
+    <value>Diretório raiz do site</value>
+  </data>
+  <data name="ManagedCertificateSettings_BrowseFolder" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="ManagedCertificateSettings_PerformChallengeResponseConfigCheck" xml:space="preserve">
+    <value>Realizar verificações de configuração de resposta ao desafio</value>
+  </data>
+  <data name="ManagedCertificateSettings_PerformWebAppAutoConfig" xml:space="preserve">
+    <value>Realizar configuração automática do aplicativo web</value>
+  </data>
+  <data name="ManagedCertificateSettings_BindIP" xml:space="preserve">
+    <value>Vincular a IP específico:</value>
+  </data>
+  <data name="ManagedCertificateSettings_BindPort" xml:space="preserve">
+    <value>Vincular à porta específica:</value>
+  </data>
+  <data name="ManagedCertificateSettings_UseSNI" xml:space="preserve">
+    <value>Usar SNI (IIS 8+):</value>
+  </data>
+  <data name="ManagedCertificateSettings_PerRequsetScript" xml:space="preserve">
+    <value>Script PS pré-solicitação:</value>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value>Teste</value>
+  </data>
+  <data name="Browser" xml:space="preserve">
+    <value>...</value>
+  </data>
+  <data name="ManagedCertificateSettings_ExportTip" xml:space="preserve">
+    <value>Nota: Para exportar este certificado, use a opção Gerenciar Certificados no Windows.</value>
+  </data>
+  <data name="ManagedCertificateSettings_OpenLogFile" xml:space="preserve">
+    <value>Abrir arquivo de log</value>
+  </data>
+  <data name="ManagedCertificateSettings_ViewCertificate" xml:space="preserve">
+    <value>Ver certificado</value>
+  </data>
+  <data name="ManagedCertificateSettings_CertificateRevokeWarning" xml:space="preserve">
+    <value>AVISO: este certificado foi revogado.</value>
+  </data>
+  <data name="SaveError" xml:space="preserve">
+    <value>Erro ao salvar</value>
+  </data>
+  <data name="ManagedCertificateSettings_SelectWebsiteOrCert" xml:space="preserve">
+    <value>Selecione o site para criar um certificado</value>
+  </data>
+  <data name="ManagedCertificateSettings_NameRequired" xml:space="preserve">
+    <value>É necessário um nome para este item.</value>
+  </data>
+  <data name="ManagedCertificateSettings_NeedPrimaryDomain" xml:space="preserve">
+    <value>Um domínio principal deve ser incluído</value>
+  </data>
+  <data name="ManagedCertificateSettings_ChallengeNotAvailable" xml:space="preserve">
+    <value>O desafio {0} está disponível apenas para versões IIS 8+.</value>
+  </data>
+  <data name="ManagedCertificateSettings_HookMustBeValidUrl" xml:space="preserve">
+    <value>A URL do webhook deve ser um URL válido.</value>
+  </data>
+  <data name="ManagedCertificateSettings_HookMethodMustBeSet" xml:space="preserve">
+    <value>O método do webhook deve ser configurado.</value>
+  </data>
+  <data name="ManagedCertificateSettings_NoChanges" xml:space="preserve">
+    <value>Nenhuma alteração realizada, omitindo salvar</value>
+  </data>
+  <data name="ConfirmDelete" xml:space="preserve">
+    <value>Confirmar exclusão</value>
+  </data>
+  <data name="ManagedCertificateSettings_ConfirmDelete" xml:space="preserve">
+    <value>Tem certeza de que deseja excluir este item? Excluí-lo não afetará a configuração do IIS etc.</value>
+  </data>
+  <data name="ManagedCertificateSettings_LogNotCreated" xml:space="preserve">
+    <value>O arquivo de log para este item ainda não foi criado.</value>
+  </data>
+  <data name="ManagedCertificateSettings_CertificateNotReady" xml:space="preserve">
+    <value>O arquivo de certificado para este item ainda não foi criado.</value>
+  </data>
+  <data name="ChallengeError" xml:space="preserve">
+    <value>Erro de desafio</value>
+  </data>
+  <data name="ManagedCertificateSettings_CannotChallengeWithoutIIS" xml:space="preserve">
+    <value>Os desafios não podem ser verificados se o IIS não estiver disponível.</value>
+  </data>
+  <data name="Challenge" xml:space="preserve">
+    <value>Desafio</value>
+  </data>
+  <data name="ManagedCertificateSettings_ConfigurationCheckOk" xml:space="preserve">
+    <value>Verificação de configuração OK</value>
+  </data>
+  <data name="ManagedCertificateSettings_ConfigurationCheckFailed" xml:space="preserve">
+    <value>Erro de verificação de configuração:
+{0}</value>
+  </data>
+  <data name="ManagedCertificateSettings_ChallengeTestFailed" xml:space="preserve">
+    <value>Teste de desafio falhou</value>
+  </data>
+  <data name="ManagedCertificateSettings_WebhookTestFailed" xml:space="preserve">
+    <value>Teste de webhook falhou</value>
+  </data>
+  <data name="ManagedCertificateSettings_WebhookTest" xml:space="preserve">
+    <value>Teste de webhook</value>
+  </data>
+  <data name="succeed" xml:space="preserve">
+    <value>sucesso</value>
+  </data>
+  <data name="failed" xml:space="preserve">
+    <value>falha</value>
+  </data>
+  <data name="ManagedCertificateSettings_WebhookRequestResult" xml:space="preserve">
+    <value>Solicitação de webhook {0}: HTTP {1}</value>
+  </data>
+  <data name="ManagedCertificateSettings_WebhookRequestError" xml:space="preserve">
+    <value>Erro na solicitação de webhook: {0}</value>
+  </data>
+  <data name="Alert" xml:space="preserve">
+    <value>Alerta</value>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>Erro</value>
+  </data>
+  <data name="ManagedCertificateSettings_Certificate_Revoked" xml:space="preserve">
+    <value>Certificado revogado.</value>
+  </data>
+  <data name="ManagedCertificateSettings_RevokeCertificateError" xml:space="preserve">
+    <value>Erro ao revogar certificado: {0}</value>
+  </data>
+  <data name="ManagedCertificateSettings_ConfirmRevokeCertificate" xml:space="preserve">
+    <value>Tem certeza de que deseja revogar este certificado?</value>
+  </data>
+  <data name="MainWindow_TrialLimitationReached" xml:space="preserve">
+    <value>Você está usando a versão de teste deste aplicativo. Por favor, compre uma chave de registro para atualizar. Veja a opção Registrar na aba Sobre.</value>
+  </data>
+  <data name="MainWindow_RenewAllConfirm" xml:space="preserve">
+    <value>Isso renovará os certificados para todos os itens de auto-renovação. Prosseguir?</value>
+  </data>
+  <data name="MainWindow_IISNotAvailable" xml:space="preserve">
+    <value>IIS não foi detectado neste servidor; vários recursos importantes não estarão disponíveis. Se o IIS estiver instalado e em execução neste servidor, informe esse erro para support@certifytheweb.com fornecendo detalhes da versão do sistema operacional do servidor e das versões do IIS.</value>
+  </data>
+  <data name="MainWindow_GetStartGuideWithNewCert" xml:space="preserve">
+    <value>Comece registrando um novo contato, depois você pode começar a solicitar certificados.</value>
+  </data>
+  <data name="MainWindow_VisitDownloadPage" xml:space="preserve">
+    <value>Deseja visitar a página de download agora?</value>
+  </data>
+  <data name="MainWindow_TitleTrialPostfix" xml:space="preserve">
+    <value>[Edição da comunidade]</value>
+  </data>
+  <data name="LanguageAuthor" xml:space="preserve">
+    <value>Colaboradores do Certify Certificate Manager https://certifytheweb.com</value>
+  </data>
+  <data name="About_LanguageTranslator" xml:space="preserve">
+    <value>Tradutor de idioma atual:</value>
+  </data>
+  <data name="Info" xml:space="preserve">
+    <value>Informação</value>
+  </data>
+  <data name="Comments" xml:space="preserve">
+    <value>Comentários:</value>
+  </data>
+  <data name="ManagedCertificateSettings_RevokeCertificate" xml:space="preserve">
+    <value>Revogar certificado</value>
+  </data>
+  <data name="ManagedCertificateSettings_HookUrl" xml:space="preserve">
+    <value>URL:</value>
+  </data>
+  <data name="ManagedCertificateSettings_HookMethod" xml:space="preserve">
+    <value>Método:</value>
+  </data>
+  <data name="ManagedCertificateSettings_HookBody" xml:space="preserve">
+    <value>Corpo:</value>
+  </data>
+  <data name="ManagedCertificateSettings_HookContentType" xml:space="preserve">
+    <value>ContentType:</value>
+  </data>
+  <data name="ManagedCertificateSettings_PostRequestScript" xml:space="preserve">
+    <value>Script PS pós-solicitação:</value>
+  </data>
+  <data name="ManagedCertificateSettings_AutoUpdateBinding" xml:space="preserve">
+    <value>Criação/atualização automática de vínculos de IIS (usa SNI)</value>
+  </data>
+  <data name="ManagedCertificateSettings_UseSpecificBinding" xml:space="preserve">
+    <value>Usar vínculos de IP/porta específicos</value>
+  </data>
+  <data name="ManagedCertificateSettings_HookTrigger" xml:space="preserve">
+    <value>Gatilho de webhook:</value>
+  </data>
+  <data name="ManagedCertificateSettings_CertificatePathEmpty" xml:space="preserve">
+    <value>Caminho do certificado: [definir]</value>
+  </data>
+  <data name="ExpiryDateConverter_NoCurrentCertificate" xml:space="preserve">
+    <value>Sem certificado atual.</value>
+  </data>
+  <data name="ExpiryDateConverter_CertificateExpiresIn" xml:space="preserve">
+    <value>Expira em {0} dias</value>
+  </data>
+  <data name="General_Loading" xml:space="preserve">
+    <value>Carregando...</value>
+  </data>
+  <data name="Update_MandatoryUpdateQuit" xml:space="preserve">
+    <value>A versão atual do aplicativo não é mais suportada. Atualize para continuar.</value>
+  </data>
+  <data name="ManagedCertificateSettings_BindingNote" xml:space="preserve">
+    <value>Nota: esta configuração se aplica apenas aos novos vínculos https; os vínculos existentes são apenas atualizados com o novo certificado. O uso de um IP fixo para vários certificados causará um conflito de vinculação no Windows, use com cautela.</value>
+  </data>
+  <data name="ManagedCertificateSettings_ReapplyCertificate" xml:space="preserve">
+    <value>Reaplicar o certificado aos vínculos</value>
+  </data>
+  <data name="Dashboard_Register" xml:space="preserve">
+    <value>Adicionar</value>
+  </data>
+  <data name="Dashboard_Password" xml:space="preserve">
+    <value>Senha</value>
+  </data>
+  <data name="GettingStarted_AddToDashboard" xml:space="preserve">
+    <value>Adicionar ao painel de relatórios</value>
+  </data>
+  <data name="GettingStarted_Dashboard" xml:space="preserve">
+    <value>Painel de relatórios</value>
+  </data>
+  <data name="GettingStarted_DashboardIntro" xml:space="preserve">
+    <value>Você pode usar o painel de relatórios para ver facilmente o status de renovação do certificado em um ou mais servidores.</value>
+  </data>
+  <data name="GettingStarted_ViewDashboard" xml:space="preserve">
+    <value>Ver painel de relatórios</value>
+  </data>
+  <data name="Dashboard_NewAccount" xml:space="preserve">
+    <value>Criar uma nova conta</value>
+  </data>
+  <data name="Dashboard_AddIntro" xml:space="preserve">
+    <value>Para adicionar este servidor ao seu painel, forneça seus detalhes de login em https://certifytheweb.com/profile ou registre uma nova conta:</value>
+  </data>
+  <data name="ScheduledTaskConfig_UseBackgroundService" xml:space="preserve">
+    <value>Usar serviço em segundo plano (executa como sistema local)</value>
+  </data>
+  <data name="ScheduledTaskConfig_UseScheduledTask" xml:space="preserve">
+    <value>Usar uma tarefa agendada (executa como usuário especificado)</value>
+  </data>
+  <data name="ManagedCertificatesSettings_RefreshDomains" xml:space="preserve">
+    <value>Atualizar</value>
+  </data>
+  <data name="Update_DownloadNow" xml:space="preserve">
+    <value>Gostaria de baixar a atualização automaticamente? Você será notificado quando estiver pronta para aplicar.</value>
+  </data>
+  <data name="Update_ReadyToApply" xml:space="preserve">
+    <value>Uma nova atualização está pronta para ser aplicada. Gostaria de instalá-la agora?</value>
+  </data>
+  <data name="ManagedCertificateSettings_InvalidSNI" xml:space="preserve">
+    <value>Você está tentando criar um vínculo SNI que também tem um endereço IP específico vinculado. Recomenda-se que os vínculos SNI usem Todos não atribuídos. Deseja continuar?</value>
+  </data>
+  <data name="Credentials_EditCredential" xml:space="preserve">
+    <value>Adicionar/atualizar credencial armazenada</value>
+  </data>
+  <data name="Update_DownloadFailed" xml:space="preserve">
+    <value>Desculpe, não foi possível baixar a atualização. Por favor, tente novamente mais tarde.</value>
+  </data>
+  <data name="ManagedCertificateSettings_DefaultTitle" xml:space="preserve">
+    <value>Novo certificado gerenciado</value>
+  </data>
+  <data name="ManagedCertificateSettings_AddDomainsToCertificate" xml:space="preserve">
+    <value>Adicione domínios ao certificado:</value>
+  </data>
+  <data name="ManagedCertificateSettings_AddDomainsHelpText" xml:space="preserve">
+    <value>ex.: test.com, www.test.com ou *.test.com</value>
+  </data>
+  <data name="Settings_EnableHttpChallengeServer" xml:space="preserve">
+    <value>Habilitar servidor de desafio HTTP</value>
+  </data>
+  <data name="Settings_EnableCertificateCleanup" xml:space="preserve">
+    <value>Habilitar limpeza de certificados</value>
+  </data>
+  <data name="Settings_EnableStatusReporting" xml:space="preserve">
+    <value>Habilitar relatórios de status no painel</value>
+  </data>
+  <data name="PreferredCertificateAuthority" xml:space="preserve">
+    <value>Autoridade de Certificação preferida</value>
+  </data>
+  <data name="MainWindow_KeyExpired" xml:space="preserve">
+    <value>Sua chave de licença expirou ou não está mais ativa.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add Brazilian Portuguese resource files for UI, core and config
- wire pt-BR resources into project build

## Testing
- `dotnet test src/Certify.Core.Service.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dc5efb10832e80edd21fa617a208