### PR TITLE
Use resource entries for GettingStarted intro

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -428,7 +428,16 @@ namespace Certify.Locales {
                 return ResourceManager.GetString("GettingStarted_AddToDashboard", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Easily automate your certificates from ACME enabled Certificate Authorities including Let's Encrypt, Google Trust Services and more, including custom or internal CAs..
+        /// </summary>
+        public static string GettingStarted_AutomateCertificatesIntro {
+            get {
+                return ResourceManager.GetString("GettingStarted_AutomateCertificatesIntro", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Dashboard.
         /// </summary>
@@ -446,7 +455,25 @@ namespace Certify.Locales {
                 return ResourceManager.GetString("GettingStarted_DashboardIntro", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Looking to manage and monitor many certificates over many servers? Check out our new product Certify Management Hub - details at https://docs.certifytheweb.com.
+        /// </summary>
+        public static string GettingStarted_ManagementHubIntro {
+            get {
+                return ResourceManager.GetString("GettingStarted_ManagementHubIntro", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to For more information, documentation, community discussions and support options, see https://certifytheweb.com.
+        /// </summary>
+        public static string GettingStarted_MoreInfoIntro {
+            get {
+                return ResourceManager.GetString("GettingStarted_MoreInfoIntro", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to View Dashboard.
         /// </summary>

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -531,11 +531,20 @@
   <data name="GettingStarted_AddToDashboard" xml:space="preserve">
     <value>Adicionar ao painel de relatórios</value>
   </data>
+  <data name="GettingStarted_AutomateCertificatesIntro" xml:space="preserve">
+    <value>Automatize facilmente seus certificados de Autoridades Certificadoras compatíveis com ACME, incluindo Let's Encrypt, Google Trust Services e outras, incluindo ACs personalizadas ou internas.</value>
+  </data>
   <data name="GettingStarted_Dashboard" xml:space="preserve">
     <value>Painel de relatórios</value>
   </data>
   <data name="GettingStarted_DashboardIntro" xml:space="preserve">
     <value>Você pode usar o painel de relatórios para ver facilmente o status de renovação do certificado em um ou mais servidores.</value>
+  </data>
+  <data name="GettingStarted_ManagementHubIntro" xml:space="preserve">
+    <value>Quer gerenciar e monitorar muitos certificados em vários servidores? Conheça nosso novo produto Certify Management Hub - detalhes em https://docs.certifytheweb.com</value>
+  </data>
+  <data name="GettingStarted_MoreInfoIntro" xml:space="preserve">
+    <value>Para mais informações, documentação, discussões da comunidade e opções de suporte, veja https://certifytheweb.com</value>
   </data>
   <data name="GettingStarted_ViewDashboard" xml:space="preserve">
     <value>Ver painel de relatórios</value>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -591,11 +591,20 @@ for the certification process to work.</value>
   <data name="GettingStarted_AddToDashboard" xml:space="preserve">
     <value>Add to Reporting Dashboard</value>
   </data>
+  <data name="GettingStarted_AutomateCertificatesIntro" xml:space="preserve">
+    <value>Easily automate your certificates from ACME enabled Certificate Authorities including Let's Encrypt, Google Trust Services and more, including custom or internal CAs.</value>
+  </data>
   <data name="GettingStarted_Dashboard" xml:space="preserve">
     <value>Dashboard</value>
   </data>
   <data name="GettingStarted_DashboardIntro" xml:space="preserve">
     <value>You can use the reporting dashboard to easily view certificate renewal status across one or more servers.</value>
+  </data>
+  <data name="GettingStarted_ManagementHubIntro" xml:space="preserve">
+    <value>Looking to manage and monitor many certificates over many servers? Check out our new product Certify Management Hub - details at https://docs.certifytheweb.com</value>
+  </data>
+  <data name="GettingStarted_MoreInfoIntro" xml:space="preserve">
+    <value>For more information, documentation, community discussions and support options, see https://certifytheweb.com</value>
   </data>
   <data name="GettingStarted_ViewDashboard" xml:space="preserve">
     <value>View Dashboard</value>

--- a/src/Certify.UI.Shared/Controls/GettingStarted.xaml
+++ b/src/Certify.UI.Shared/Controls/GettingStarted.xaml
@@ -37,10 +37,11 @@
                     Text="Gerenciador de Certificados"
                     TextWrapping="Wrap" />
                 <TextBlock Style="{StaticResource Instructions}" TextWrapping="Wrap">
-                    <Run>Easily automate your certificates from ACME enabled Certificate Authorities including Let's Encrypt, Google Trust Services and more, including custom or internal CAs.</Run>
-                    <Run>For more information, documentation, community discussions and support options, see https://certifytheweb.com</Run>
-                    <LineBreak />  <LineBreak />
-                    <Run>Looking to manage and monitor many certificates over many servers? Check out our new product Certify Management Hub - details at https://docs.certifytheweb.com</Run>
+                    <Run Text="{x:Static res:SR.GettingStarted_AutomateCertificatesIntro}" />
+                    <Run Text="{x:Static res:SR.GettingStarted_MoreInfoIntro}" />
+                    <LineBreak />
+                    <LineBreak />
+                    <Run Text="{x:Static res:SR.GettingStarted_ManagementHubIntro}" />
 
                 </TextBlock>
 


### PR DESCRIPTION
## Summary
- replace hard-coded intro text in GettingStarted control with localized resources
- add English and pt-BR resource strings for new GettingStarted intro messages
- expose new strongly-typed resource properties

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a91b2c6c4c832e94bd3c96ccb9bc92