### PR TITLE
feat: localize license warning

### DIFF
--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -540,6 +540,12 @@
   <data name="GettingStarted_DashboardIntro" xml:space="preserve">
     <value>Você pode usar o painel de relatórios para ver facilmente o status de renovação do certificado em um ou mais servidores.</value>
   </data>
+  <data name="GettingStarted_LicenseNotActivatedTitle" xml:space="preserve">
+    <value>Licença não ativada</value>
+  </data>
+  <data name="GettingStarted_LicenseNotActivatedMessage" xml:space="preserve">
+    <value>Você está usando a Community Edition sem licença. Se estiver usando este aplicativo em uma empresa ou organização financiada, você deve adquirir uma chave de licença quando concluir sua avaliação e então usar Sobre &gt; Inserir chave.. para ativar. Visite certifytheweb.com/register para mais informações.</value>
+  </data>
   <data name="GettingStarted_ManagementHubIntro" xml:space="preserve">
     <value>Quer gerenciar e monitorar muitos certificados em vários servidores? Conheça nosso novo produto Certify Management Hub - detalhes em https://docs.certifytheweb.com</value>
   </data>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -600,6 +600,12 @@ for the certification process to work.</value>
   <data name="GettingStarted_DashboardIntro" xml:space="preserve">
     <value>You can use the reporting dashboard to easily view certificate renewal status across one or more servers.</value>
   </data>
+  <data name="GettingStarted_LicenseNotActivatedTitle" xml:space="preserve">
+    <value>License Not Activated</value>
+  </data>
+  <data name="GettingStarted_LicenseNotActivatedMessage" xml:space="preserve">
+    <value>You are using the unlicensed Community Edition. If you are using this application within a business or funded organisation you should purchase a license key when you have completed your evaluation, then use About &gt; Enter Key.. to activate. Visit certifytheweb.com/register for more information.</value>
+  </data>
   <data name="GettingStarted_ManagementHubIntro" xml:space="preserve">
     <value>Looking to manage and monitor many certificates over many servers? Check out our new product Certify Management Hub - details at https://docs.certifytheweb.com</value>
   </data>

--- a/src/Certify.UI.Shared/Controls/GettingStarted.xaml
+++ b/src/Certify.UI.Shared/Controls/GettingStarted.xaml
@@ -50,12 +50,12 @@
                     Margin="0,16,0,0"
                     Custom:HeaderedControlHelper.HeaderBackground="{StaticResource ErrorColorBrush}"
                     BorderThickness="0"
-                    Header="License Not Activated"
+                    Header="{x:Static res:SR.GettingStarted_LicenseNotActivatedTitle}"
                     Visibility="{Binding IsLicenseUpgradeRecommended, Converter={StaticResource ResourceKey=BooleanToVisibilityConverter}}">
                     <StackPanel>
 
                         <TextBlock Margin="8" Style="{StaticResource Instructions}">
-                            <Run Text="You are using the unlicensed Community Edition. If you are using this application within a business or funded organisation you should purchase a license key when you have completed your evaluation, then use About &gt; Enter Key.. to activate. Visit certifytheweb.com/register for more information." />
+                            <Run Text="{x:Static res:SR.GettingStarted_LicenseNotActivatedMessage}" />
 
                         </TextBlock>
                     </StackPanel>


### PR DESCRIPTION
## Summary
- add global resources for unlicensed community edition warning
- reference new resource strings in GettingStarted panel

## Testing
- `dotnet test src/Certify.Tests` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a91cf8d03c832e8b7f7a88ef4096b3