### PR TITLE
feat: localize license expiration notice

### DIFF
--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -540,6 +540,9 @@
   <data name="GettingStarted_DashboardIntro" xml:space="preserve">
     <value>Você pode usar o painel de relatórios para ver facilmente o status de renovação do certificado em um ou mais servidores.</value>
   </data>
+  <data name="GettingStarted_LicenseExpiredMessage" xml:space="preserve">
+    <value>Sua chave de licença expirou. Alguns recursos serão reduzidos ou ficarão indisponíveis. Faça login em https://certifytheweb.com e renove sua chave de licença, depois reabra o aplicativo.</value>
+  </data>
   <data name="GettingStarted_LicenseNotActivatedTitle" xml:space="preserve">
     <value>Licença não ativada</value>
   </data>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -600,6 +600,9 @@ for the certification process to work.</value>
   <data name="GettingStarted_DashboardIntro" xml:space="preserve">
     <value>You can use the reporting dashboard to easily view certificate renewal status across one or more servers.</value>
   </data>
+  <data name="GettingStarted_LicenseExpiredMessage" xml:space="preserve">
+    <value>Your license key has expired. Some features will be reduced or unavailable. Please Sign In to https://certifytheweb.com and renew your license key, then re-open the app.</value>
+  </data>
   <data name="GettingStarted_LicenseNotActivatedTitle" xml:space="preserve">
     <value>License Not Activated</value>
   </data>

--- a/src/Certify.UI.Shared/Controls/GettingStarted.xaml
+++ b/src/Certify.UI.Shared/Controls/GettingStarted.xaml
@@ -74,7 +74,7 @@
                         FontSize="12"
                         FontWeight="Bold"
                         Foreground="{StaticResource MahApps.Brushes.IdealForeground}"
-                        Text="Your license key has expired. Some features will be reduced or unavailable. Please Sign In to https://certifytheweb.com and renew your license key, then re-open the app."
+                        Text="{x:Static res:SR.GettingStarted_LicenseExpiredMessage}"
                         TextWrapping="Wrap" />
 
                 </StackPanel>


### PR DESCRIPTION
## Summary
- add `GettingStarted_LicenseExpiredMessage` strings for en and pt-BR
- use localized resource for expired license message in GettingStarted view

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a91dc83af0832e8a015a7b42f19b7b