### PR TITLE
feat: localize getting started heading

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -475,6 +475,24 @@ namespace Certify.Locales {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Quick Start Guide.
+        /// </summary>
+        public static string GettingStarted_QuickStartGuide {
+            get {
+                return ResourceManager.GetString("GettingStarted_QuickStartGuide", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Getting Started.
+        /// </summary>
+        public static string GettingStarted_Title {
+            get {
+                return ResourceManager.GetString("GettingStarted_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to View Dashboard.
         /// </summary>
         public static string GettingStarted_ViewDashboard {

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -555,6 +555,12 @@
   <data name="GettingStarted_MoreInfoIntro" xml:space="preserve">
     <value>Para mais informações, documentação, discussões da comunidade e opções de suporte, veja https://certifytheweb.com</value>
   </data>
+  <data name="GettingStarted_QuickStartGuide" xml:space="preserve">
+    <value>Guia de início rápido</value>
+  </data>
+  <data name="GettingStarted_Title" xml:space="preserve">
+    <value>Introdução</value>
+  </data>
   <data name="GettingStarted_ViewDashboard" xml:space="preserve">
     <value>Ver painel de relatórios</value>
   </data>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -615,6 +615,12 @@ for the certification process to work.</value>
   <data name="GettingStarted_MoreInfoIntro" xml:space="preserve">
     <value>For more information, documentation, community discussions and support options, see https://certifytheweb.com</value>
   </data>
+  <data name="GettingStarted_QuickStartGuide" xml:space="preserve">
+    <value>Quick Start Guide</value>
+  </data>
+  <data name="GettingStarted_Title" xml:space="preserve">
+    <value>Getting Started</value>
+  </data>
   <data name="GettingStarted_ViewDashboard" xml:space="preserve">
     <value>View Dashboard</value>
   </data>

--- a/src/Certify.UI.Shared/Controls/GettingStarted.xaml
+++ b/src/Certify.UI.Shared/Controls/GettingStarted.xaml
@@ -99,9 +99,8 @@
                         HorizontalAlignment="Left"
                         VerticalAlignment="Top"
                         FontSize="20"
-                        TextWrapping="Wrap">
-                        Getting Started
-                    </TextBlock>
+                        TextWrapping="Wrap"
+                        Text="{x:Static res:SR.GettingStarted_Title}" />
 
                     <TextBlock
                         Margin="0,0,0,0"
@@ -122,7 +121,10 @@
                                 VerticalAlignment="Center"
                                 Foreground="#FF6BB039"
                                 Icon="PlayCircle" />
-                            <TextBlock Margin="8,0,0,0" HorizontalAlignment="Left"><Run Text="Quick Start Guide" /></TextBlock>
+                            <TextBlock
+                                Margin="8,0,0,0"
+                                HorizontalAlignment="Left"
+                                Text="{x:Static res:SR.GettingStarted_QuickStartGuide}" />
                         </StackPanel>
                     </Button>
                 </StackPanel>


### PR DESCRIPTION
## Summary
- localize Getting Started and Quick Start Guide labels
- reference new resource keys in GettingStarted.xaml

## Testing
- `dotnet build src/Certify.Locales/Certify.Locales.csproj` *(command failed: dotnet: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a91e861c7c832ea3cdff0ff97a3f25