### PR TITLE
Externalize IIS version warning text

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -457,6 +457,24 @@ namespace Certify.Locales {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Warning: Your version of Windows/IIS has limited SSL Support.
+        /// </summary>
+        public static string GettingStarted_IISVersionWarningTitle {
+            get {
+                return ResourceManager.GetString("GettingStarted_IISVersionWarningTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to IIS Versions below 8.0 lack SNI support. This means that only one certificate can be used per IP address for standard https. If you require more than a single certificate you will need to ensure each certificate binding is associated with its own IP address otherwise you may encounter binding conflicts.
+        /// </summary>
+        public static string GettingStarted_IISVersionWarningMessage {
+            get {
+                return ResourceManager.GetString("GettingStarted_IISVersionWarningMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Looking to manage and monitor many certificates over many servers? Check out our new product Certify Management Hub - details at https://docs.certifytheweb.com.
         /// </summary>
         public static string GettingStarted_ManagementHubIntro {

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -540,6 +540,12 @@
   <data name="GettingStarted_DashboardIntro" xml:space="preserve">
     <value>Você pode usar o painel de relatórios para ver facilmente o status de renovação do certificado em um ou mais servidores.</value>
   </data>
+  <data name="GettingStarted_IISVersionWarningTitle" xml:space="preserve">
+    <value>Aviso: Sua versão do Windows/IIS possui suporte SSL limitado</value>
+  </data>
+  <data name="GettingStarted_IISVersionWarningMessage" xml:space="preserve">
+    <value>Versões do IIS abaixo da 8.0 não possuem suporte a SNI. Isso significa que apenas um certificado pode ser usado por endereço IP para https padrão. Se você precisar de mais de um único certificado, será necessário garantir que cada associação de certificado esteja associada ao seu próprio endereço IP, caso contrário você poderá encontrar conflitos de associação.</value>
+  </data>
   <data name="GettingStarted_LicenseExpiredMessage" xml:space="preserve">
     <value>Sua chave de licença expirou. Alguns recursos serão reduzidos ou ficarão indisponíveis. Faça login em https://certifytheweb.com e renove sua chave de licença, depois reabra o aplicativo.</value>
   </data>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -600,6 +600,12 @@ for the certification process to work.</value>
   <data name="GettingStarted_DashboardIntro" xml:space="preserve">
     <value>You can use the reporting dashboard to easily view certificate renewal status across one or more servers.</value>
   </data>
+  <data name="GettingStarted_IISVersionWarningTitle" xml:space="preserve">
+    <value>Warning: Your version of Windows/IIS has limited SSL Support</value>
+  </data>
+  <data name="GettingStarted_IISVersionWarningMessage" xml:space="preserve">
+    <value>IIS Versions below 8.0 lack SNI support. This means that only one certificate can be used per IP address for standard https. If you require more than a single certificate you will need to ensure each certificate binding is associated with its own IP address otherwise you may encounter binding conflicts.</value>
+  </data>
   <data name="GettingStarted_LicenseExpiredMessage" xml:space="preserve">
     <value>Your license key has expired. Some features will be reduced or unavailable. Please Sign In to https://certifytheweb.com and renew your license key, then re-open the app.</value>
   </data>

--- a/src/Certify.UI.Shared/Controls/GettingStarted.xaml
+++ b/src/Certify.UI.Shared/Controls/GettingStarted.xaml
@@ -196,11 +196,11 @@
                         VerticalAlignment="Top"
                         FontSize="20"
                         Foreground="White"
-                        TextWrapping="Wrap"><Run Text="Warning: Your version of Windows/IIS has limited SSL Support" /></TextBlock>
+                        TextWrapping="Wrap"><Run Text="{x:Static res:SR.GettingStarted_IISVersionWarningTitle}" /></TextBlock>
                     <TextBlock
                         Margin="16,8,0,16"
                         Foreground="White"
-                        Style="{StaticResource Instructions}"><Run Text="IIS Versions below 8.0 lack SNI support. This means that only one certificate can be used per IP address for standard https. If you require more than a single certificate you will need to ensure each certificate binding is associated with its own IP address otherwise you may encounter binding conflicts." /></TextBlock>
+                        Style="{StaticResource Instructions}"><Run Text="{x:Static res:SR.GettingStarted_IISVersionWarningMessage}" /></TextBlock>
                 </StackPanel>
 
                 <StackPanel


### PR DESCRIPTION
## Summary
- add resource keys for IIS version warning title and message in English and Portuguese
- replace hardcoded IIS warning text in GettingStarted.xaml with resource references

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a920500944832e9f43f9a4c837b99a