### PR TITLE
chore: localize managed certificate tabs

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -1280,11 +1280,56 @@ namespace Certify.Locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Status.
+        /// </summary>
+        public static string ManagedCertificateSettings_Tab_Status {
+            get {
+                return ResourceManager.GetString("ManagedCertificateSettings_Tab_Status", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Certificate.
+        /// </summary>
+        public static string ManagedCertificateSettings_Tab_Certificate {
+            get {
+                return ResourceManager.GetString("ManagedCertificateSettings_Tab_Certificate", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deployment.
+        /// </summary>
+        public static string ManagedCertificateSettings_Tab_Deployment {
+            get {
+                return ResourceManager.GetString("ManagedCertificateSettings_Tab_Deployment", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Options.
         /// </summary>
         public static string ManagedCertificateSettings_Tab_Options {
             get {
                 return ResourceManager.GetString("ManagedCertificateSettings_Tab_Options", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Preview.
+        /// </summary>
+        public static string ManagedCertificateSettings_Tab_Preview {
+            get {
+                return ResourceManager.GetString("ManagedCertificateSettings_Tab_Preview", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tasks.
+        /// </summary>
+        public static string ManagedCertificateSettings_Tab_Tasks {
+            get {
+                return ResourceManager.GetString("ManagedCertificateSettings_Tab_Tasks", resourceCulture);
             }
         }
         

--- a/src/Certify.Locales/SR.es-ES.resx
+++ b/src/Certify.Locales/SR.es-ES.resx
@@ -339,6 +339,21 @@
   <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
     <value>Opciones</value>
   </data>
+  <data name="ManagedCertificateSettings_Tab_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Certificate" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Deployment" xml:space="preserve">
+    <value>Deployment</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Tasks" xml:space="preserve">
+    <value>Tasks</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
   <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
     <value>Seleccione el sitio IIS:</value>
   </data>

--- a/src/Certify.Locales/SR.ja-JP.resx
+++ b/src/Certify.Locales/SR.ja-JP.resx
@@ -327,6 +327,21 @@
   <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
     <value>オプション</value>
   </data>
+  <data name="ManagedCertificateSettings_Tab_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Certificate" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Deployment" xml:space="preserve">
+    <value>Deployment</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Tasks" xml:space="preserve">
+    <value>Tasks</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
   <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
     <value>Web サイトを選択 (オプション):</value>
   </data>

--- a/src/Certify.Locales/SR.nb-NO.resx
+++ b/src/Certify.Locales/SR.nb-NO.resx
@@ -321,6 +321,21 @@
   <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
     <value>Valg</value>
   </data>
+  <data name="ManagedCertificateSettings_Tab_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Certificate" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Deployment" xml:space="preserve">
+    <value>Deployment</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Tasks" xml:space="preserve">
+    <value>Tasks</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
   <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
     <value>Velg IIS-nettsted</value>
   </data>

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -281,6 +281,21 @@
   <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
     <value>Opções</value>
   </data>
+  <data name="ManagedCertificateSettings_Tab_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Certificate" xml:space="preserve">
+    <value>Certificado</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Deployment" xml:space="preserve">
+    <value>Implantação</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Tasks" xml:space="preserve">
+    <value>Tarefas</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Preview" xml:space="preserve">
+    <value>Visualização</value>
+  </data>
   <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
     <value>Selecione o site IIS:</value>
   </data>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -339,6 +339,21 @@
   <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
     <value>Options</value>
   </data>
+  <data name="ManagedCertificateSettings_Tab_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Certificate" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Deployment" xml:space="preserve">
+    <value>Deployment</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Tasks" xml:space="preserve">
+    <value>Tasks</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
   <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
     <value>Select Site (optional):</value>
   </data>

--- a/src/Certify.Locales/SR.tr-TR.resx
+++ b/src/Certify.Locales/SR.tr-TR.resx
@@ -339,6 +339,21 @@
   <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
     <value>Seçenekler</value>
   </data>
+  <data name="ManagedCertificateSettings_Tab_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Certificate" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Deployment" xml:space="preserve">
+    <value>Deployment</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Tasks" xml:space="preserve">
+    <value>Tasks</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
   <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
     <value>Site Seçin (isteğe bağlı):</value>
   </data>

--- a/src/Certify.Locales/SR.zh-Hans.resx
+++ b/src/Certify.Locales/SR.zh-Hans.resx
@@ -339,6 +339,21 @@
   <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
     <value>选项</value>
   </data>
+  <data name="ManagedCertificateSettings_Tab_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Certificate" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Deployment" xml:space="preserve">
+    <value>Deployment</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Tasks" xml:space="preserve">
+    <value>Tasks</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
   <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
     <value>选择站点（可选）：</value>
   </data>

--- a/src/Certify.Locales/SR.zh-Hant.resx
+++ b/src/Certify.Locales/SR.zh-Hant.resx
@@ -339,6 +339,21 @@
   <data name="ManagedCertificateSettings_Tab_Options" xml:space="preserve">
     <value>選項</value>
   </data>
+  <data name="ManagedCertificateSettings_Tab_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Certificate" xml:space="preserve">
+    <value>Certificate</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Deployment" xml:space="preserve">
+    <value>Deployment</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Tasks" xml:space="preserve">
+    <value>Tasks</value>
+  </data>
+  <data name="ManagedCertificateSettings_Tab_Preview" xml:space="preserve">
+    <value>Preview</value>
+  </data>
   <data name="ManagedCertificateSettings_SelectWebsite" xml:space="preserve">
     <value>選擇網站（可選）：</value>
   </data>

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/ManagedCertificateSettings.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/ManagedCertificateSettings.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
     xmlns:Custom="http://metro.mahapps.com/winfx/xaml/controls"
-    xmlns:Resources="clr-namespace:Certify.Locales;assembly=Certify.Locales"
+    xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     xmlns:certifyui="clr-namespace:Certify.UI"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:fa="http://schemas.fontawesome.io/icons/"
@@ -134,7 +134,7 @@
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource MahApps.Brushes.Accent}"
                         Icon="Save" />
-                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static Resources:SR.Save}" /></TextBlock>
+                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static res:SR.Save}" /></TextBlock>
                 </StackPanel>
             </Button>
 
@@ -150,7 +150,7 @@
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource MahApps.Brushes.Accent}"
                         Icon="Undo" />
-                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static Resources:SR.DiscardChanges}" /></TextBlock>
+                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static res:SR.DiscardChanges}" /></TextBlock>
                 </StackPanel>
             </Button>
 
@@ -165,7 +165,7 @@
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource MahApps.Brushes.Accent}"
                         Icon="Trash" />
-                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static Resources:SR.Delete}" /></TextBlock>
+                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static res:SR.Delete}" /></TextBlock>
                 </StackPanel>
             </Button>
 
@@ -180,7 +180,7 @@
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource MahApps.Brushes.Accent}"
                         Icon="Play" />
-                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static Resources:SR.ManagedCertificateSettings_RequestCertificate}" /></TextBlock>
+                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static res:SR.ManagedCertificateSettings_RequestCertificate}" /></TextBlock>
                 </StackPanel>
             </Button>
 
@@ -211,7 +211,7 @@
                         Icon="CheckCircle"
                         Spin="False"
                         Visibility="{Binding IsTestInProgress, Converter={StaticResource ResourceKey=InvBoolToVisConverter}}" />
-                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static Resources:SR.Test}" /></TextBlock>
+                    <TextBlock Margin="8,0,0,0" VerticalAlignment="Center"><Run Text="{x:Static res:SR.Test}" /></TextBlock>
                 </StackPanel>
             </Button>
         </DockPanel>
@@ -239,10 +239,10 @@
                     x:Name="TabStatusInfo"
                     MinWidth="100"
                     Controls:HeaderedControlHelper.HeaderFontSize="12"
-                    AutomationProperties.Name="Status">
+                    AutomationProperties.Name="{x:Static res:SR.ManagedCertificateSettings_Tab_Status}">
                     <TabItem.HeaderTemplate>
                         <DataTemplate>
-                            <managedcertificate:TabHeader HeaderText="Status" IconName="Support" />
+                            <managedcertificate:TabHeader HeaderText="{x:Static res:SR.ManagedCertificateSettings_Tab_Status}" IconName="Support" />
                         </DataTemplate>
                     </TabItem.HeaderTemplate>
                     <managedcertificate:StatusInfo Margin="0,8,0,0" />
@@ -253,11 +253,11 @@
                     MinWidth="130"
                     Margin="0"
                     Controls:HeaderedControlHelper.HeaderFontSize="12"
-                    AutomationProperties.Name="Certificate"
+                    AutomationProperties.Name="{x:Static res:SR.ManagedCertificateSettings_Tab_Certificate}"
                     IsSelected="True">
                     <TabItem.HeaderTemplate>
                         <DataTemplate>
-                            <managedcertificate:TabHeader HeaderText="Certificate" IconName="Globe" />
+                            <managedcertificate:TabHeader HeaderText="{x:Static res:SR.ManagedCertificateSettings_Tab_Certificate}" IconName="Globe" />
                         </DataTemplate>
                     </TabItem.HeaderTemplate>
                     <managedcertificate:CertificateIdentifiers Margin="0,8,0,0" />
@@ -267,10 +267,10 @@
                     x:Name="TabDeployment"
                     MinWidth="100"
                     Controls:HeaderedControlHelper.HeaderFontSize="12"
-                    AutomationProperties.Name="Deployment">
+                    AutomationProperties.Name="{x:Static res:SR.ManagedCertificateSettings_Tab_Deployment}">
                     <TabItem.HeaderTemplate>
                         <DataTemplate>
-                            <managedcertificate:TabHeader HeaderText="Deployment" IconName="Copy" />
+                            <managedcertificate:TabHeader HeaderText="{x:Static res:SR.ManagedCertificateSettings_Tab_Deployment}" IconName="Copy" />
                         </DataTemplate>
                     </TabItem.HeaderTemplate>
                     <managedcertificate:Deployment Margin="0,8,0,0" />
@@ -280,10 +280,10 @@
                     x:Name="TabTasks"
                     MinWidth="100"
                     Controls:HeaderedControlHelper.HeaderFontSize="12"
-                    AutomationProperties.Name="Tasks">
+                    AutomationProperties.Name="{x:Static res:SR.ManagedCertificateSettings_Tab_Tasks}">
                     <TabItem.HeaderTemplate>
                         <DataTemplate>
-                            <managedcertificate:TabHeader HeaderText="Tasks" IconName="Cogs" />
+                            <managedcertificate:TabHeader HeaderText="{x:Static res:SR.ManagedCertificateSettings_Tab_Tasks}" IconName="Cogs" />
                         </DataTemplate>
                     </TabItem.HeaderTemplate>
                     <managedcertificate:Tasks Margin="0,8,0,0" />
@@ -295,10 +295,10 @@
                     x:Name="TabPreview"
                     MinWidth="100"
                     Controls:HeaderedControlHelper.HeaderFontSize="12"
-                    AutomationProperties.Name="Preview">
+                    AutomationProperties.Name="{x:Static res:SR.ManagedCertificateSettings_Tab_Preview}">
                     <TabItem.HeaderTemplate>
                         <DataTemplate>
-                            <managedcertificate:TabHeader HeaderText="Preview" IconName="PlayCircle" />
+                            <managedcertificate:TabHeader HeaderText="{x:Static res:SR.ManagedCertificateSettings_Tab_Preview}" IconName="PlayCircle" />
                         </DataTemplate>
                     </TabItem.HeaderTemplate>
                     <managedcertificate:Preview Margin="0,8,0,0" />


### PR DESCRIPTION
## Summary
- add SR resource keys for managed certificate settings tabs
- update tab header text and automation names to use localized strings

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9216bb9e4832e903c6cb9fb9c74cb