### PR TITLE
Update SR.Designer for license activation messages

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -475,6 +475,33 @@ namespace Certify.Locales {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Your license key has expired. Some features will be reduced or unavailable. Please Sign In to https://certifytheweb.com and renew your license key, then re-open the app.
+        /// </summary>
+        public static string GettingStarted_LicenseExpiredMessage {
+            get {
+                return ResourceManager.GetString("GettingStarted_LicenseExpiredMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You are using the unlicensed Community Edition. If you are using this application within a business or funded organisation you should purchase a license key when you have completed your evaluation, then use About > Enter Key.. to activate. Visit certifytheweb.com/register for more information.
+        /// </summary>
+        public static string GettingStarted_LicenseNotActivatedMessage {
+            get {
+                return ResourceManager.GetString("GettingStarted_LicenseNotActivatedMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to License Not Activated.
+        /// </summary>
+        public static string GettingStarted_LicenseNotActivatedTitle {
+            get {
+                return ResourceManager.GetString("GettingStarted_LicenseNotActivatedTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Looking to manage and monitor many certificates over many servers? Check out our new product Certify Management Hub - details at https://docs.certifytheweb.com.
         /// </summary>
         public static string GettingStarted_ManagementHubIntro {


### PR DESCRIPTION
## Summary
- add localized string properties for license expiration and activation warnings

## Testing
- `dotnet build src/Certify.UI.Shared/Certify.UI.Shared.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a924a9b83c832e9e43566423b3537b