### PR TITLE
Remove community mode prompts from MainWindow

### DIFF
--- a/src/Certify.UI.Shared/Windows/MainWindow.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/MainWindow.xaml.cs
@@ -24,9 +24,6 @@ namespace Certify.UI.Windows
         protected static ViewModel.AppViewModel _appViewModel => ViewModel.AppViewModel.Current;
         protected static ViewModel.ManagedCertificateViewModel _itemViewModel => UI.ViewModel.ManagedCertificateViewModel.Current;
 
-        private const int NUM_ITEMS_FOR_REMINDER = 3;
-        private const int NUM_ITEMS_FOR_LIMIT = 5;
-        private const int NUM_ITEMS_FOR_LEGACY_INSTALL = 10;
         private System.Timers.Timer _periodicCheckTimer;
 
         public int NumManagedCertificates
@@ -58,37 +55,6 @@ namespace Certify.UI.Windows
             if (!await _itemViewModel.ConfirmDiscardUnsavedChanges())
             {
                 return;
-            }
-
-            if (!_appViewModel.IsRegisteredVersion && _appViewModel.NumManagedCerts >= NUM_ITEMS_FOR_REMINDER)
-            {
-                MessageBox.Show(SR.MainWindow_TrialLimitationReached);
-
-                if (_appViewModel.IsInstallBeforeDate(new System.DateTime(2023, 1, 1)))
-                {
-                    if (_appViewModel.NumManagedCerts >= NUM_ITEMS_FOR_LEGACY_INSTALL)
-                    {
-                        return;
-                    }
-                }
-                else
-                {
-                    if (_appViewModel.NumManagedCerts >= NUM_ITEMS_FOR_LIMIT)
-                    {
-                        return;
-                    }
-                }
-            }
-            else
-            {
-                if (_appViewModel.IsLicenseExpired)
-                {
-                    MessageBox.Show(Certify.Locales.SR.MainWindow_KeyExpired);
-                    if (_appViewModel.NumManagedCerts >= NUM_ITEMS_FOR_LIMIT)
-                    {
-                        return;
-                    }
-                }
             }
 
             // check user has registered a contact with ACME CA first
@@ -332,49 +298,10 @@ namespace Certify.UI.Windows
                 }
             }
 
-            // set title etc based on license status
+            // set title based on license status
             if (!_appViewModel.IsRegisteredVersion)
             {
                 Title += SR.MainWindow_TitleTrialPostfix;
-
-                if (_appViewModel.UISettings == null)
-                {
-                    _appViewModel.UISettings = new UISettings();
-                }
-
-                if (_appViewModel.UISettings?.CommunityMode == "personal")
-                {
-                    Title += " [Personal Use]";
-                }
-                else if (_appViewModel.NumManagedCerts > 0 && _appViewModel.UISettings?.CommunityMode != "personal")
-                {
-                    var evaluating = MessageBox.Show(this, "You are currently using the Community Edition of this app intended for personal use or evaluation. Are you still evaluating the app?", "Continue Evaluation?", MessageBoxButton.YesNo);
-
-                    if (evaluating == MessageBoxResult.No)
-                    {
-                        var personalUse = MessageBox.Show(this, "Are you using the app for personal use?", "Confirm Usage", MessageBoxButton.YesNo);
-
-                        if (personalUse == MessageBoxResult.No)
-                        {
-                            MessageBox.Show(this, "Please purchase a license to continue using the app for non-personal use.");
-
-                            _appViewModel.UISettings.CommunityMode = "commercial";
-                            UISettings.Save(_appViewModel.UISettings);
-                        }
-                        else
-                        {
-                            MessageBox.Show(this, "You are using the app for personal use. Please continue using the app for free. Tell your friends about us and star webprofusion/certify on github.");
-
-                            _appViewModel.UISettings.CommunityMode = "personal";
-                            UISettings.Save(_appViewModel.UISettings);
-                        }
-                    }
-                    else
-                    {
-                        _appViewModel.UISettings.CommunityMode = "evaluating";
-                        UISettings.Save(_appViewModel.UISettings);
-                    }
-                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- remove licensing restriction and community mode prompts
- stop appending personal-use text to main window title
- simplify startup logic to avoid storing community mode state

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a92942c8cc832e8f68a229e8247296