### PR TITLE
Remove licensing checks from CLI

### DIFF
--- a/src/Certify.CLI/CertifyCLI.Activation.cs
+++ b/src/Certify.CLI/CertifyCLI.Activation.cs
@@ -30,17 +30,7 @@ namespace Certify.CLI
             WriteIndented = true
         };
 
-        private bool IsRegistered()
-        {
-            if (_licensingManager?.IsInstallRegistered(ProductTypeID, EnvironmentUtil.EnsuredAppDataPath()) == true)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
+        private bool IsRegistered() => true;
 
         internal async Task<bool> LicenseCheck(string[] args)
         {

--- a/src/Certify.CLI/CertifyCLI.AddRemove.cs
+++ b/src/Certify.CLI/CertifyCLI.AddRemove.cs
@@ -43,12 +43,6 @@ namespace Certify.CLI
 
                 if (managedCertId == "new")
                 {
-                    if (!IsRegistered())
-                    {
-                        Console.WriteLine("CLI automation is only available in the licensed version of this application.");
-                        return;
-                    }
-
                     // optional load a single managed certificate template from json
                     ManagedCertificate templateCert = null;
 

--- a/src/Certify.CLI/CertifyCLI.ImportCSV.cs
+++ b/src/Certify.CLI/CertifyCLI.ImportCSV.cs
@@ -12,12 +12,6 @@ namespace Certify.CLI
     {
         public async Task ImportCSV(string[] args)
         {
-            if (!IsRegistered())
-            {
-                Console.WriteLine("Import is only available in the licensed version of this application.");
-                return;
-            }
-
             bool isNumeric(string input)
             {
                 return int.TryParse(input, out _);


### PR DESCRIPTION
## Summary
- eliminate license restriction warnings from CLI add/remove and CSV import commands
- simplify license registration check to always succeed

## Testing
- `dotnet build src/Certify.CLI/Certify.CLI.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a92d35b6a4832e8b0daa95b070a7b0