### PR TITLE
Add AutoIP DNS provider reference to unit tests

### DIFF
--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj
@@ -75,6 +75,7 @@
         <ProjectReference Include="..\..\Certify.Core\Certify.Core.csproj" />
 
         <ProjectReference Include="..\..\Certify.Providers\ACME\Anvil\Certify.Providers.ACME.Anvil.csproj" />
+        <ProjectReference Include="..\..\Certify.Providers\DNS\AutoIP\Plugin.DNS.AutoIP.csproj" />
         <ProjectReference Include="..\..\Certify.Shared\Certify.Shared.Core.csproj" />
         <ProjectReference Include="..\..\Certify.SourceGenerators\Certify.SourceGenerators.csproj" />
 


### PR DESCRIPTION
## Summary
- include Plugin.DNS.AutoIP project in Certify.Core.Tests.Unit

## Testing
- `dotnet build src/Certify.Core.Service.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa05d26a28832eab87fa29007aeed8