### PR TITLE
Localize managed certificate UI text

### DIFF
--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -696,4 +696,73 @@
   <data name="ManagedCertificateSettings_CertificateAuthority_PreferredChain_Instructions" xml:space="preserve">
     <value> A autoridade certificadora pode apresentar várias versões do seu certificado assinadas com certificados raiz (emissores) diferentes e você pode especificar uma preferência para esse certificado. Se a cadeia exata não estiver disponível, a cadeia padrão será usada.</value>
   </data>
+  <data name="Dashboard_Summary" xml:space="preserve">
+    <value>Resumo</value>
+  </data>
+  <data name="Dashboard_ManagedCertificates" xml:space="preserve">
+    <value>Certificados Gerenciados</value>
+  </data>
+  <data name="Dashboard_Healthy" xml:space="preserve">
+    <value>Saudáveis</value>
+  </data>
+  <data name="Dashboard_Errors" xml:space="preserve">
+    <value>Erros</value>
+  </data>
+  <data name="Dashboard_Warnings" xml:space="preserve">
+    <value>Avisos</value>
+  </data>
+  <data name="Dashboard_AwaitingUser" xml:space="preserve">
+    <value>Aguardando Usuário</value>
+  </data>
+  <data name="Dashboard_TotalDomains" xml:space="preserve">
+    <value>Total de Domínios</value>
+  </data>
+  <data name="Dashboard_InvalidConfig" xml:space="preserve">
+    <value>Configuração Inválida</value>
+  </data>
+  <data name="Dashboard_NoCertificate" xml:space="preserve">
+    <value>Sem Certificado</value>
+  </data>
+  <data name="Preview_Title" xml:space="preserve">
+    <value>Pré-visualização</value>
+  </data>
+  <data name="Preview_Intro" xml:space="preserve">
+    <value>A seguir está uma pré-visualização das ações que serão executadas com base nessas configurações:</value>
+  </data>
+  <data name="RunTask" xml:space="preserve">
+    <value>Executar Tarefa</value>
+  </data>
+  <data name="StatusLabel" xml:space="preserve">
+    <value>Status: </value>
+  </data>
+  <data name="ManagedCertificates_Tasks_DeploymentTasks" xml:space="preserve">
+    <value>Tarefas de Implantação</value>
+  </data>
+  <data name="ManagedCertificates_Tasks_PreRequestTasks" xml:space="preserve">
+    <value>Tarefas Pré-Requisição</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Adicionar</value>
+  </data>
+  <data name="IdentifierAuthorization_Title" xml:space="preserve">
+    <value>Autorização de Identificador</value>
+  </data>
+  <data name="IdentifierAuthorization_Intro" xml:space="preserve">
+    <value>Para que um certificado seja emitido você deve provar controle dos domínios ou outros identificadores no seu pedido de certificado. Para domínios, você pode validar usando HTTP (porta 80) ou via DNS. Se qualquer identificador incluído falhar na validação, o pedido de certificado não poderá ser concluído.</value>
+  </data>
+  <data name="IdentifierAuthorization_ChallengeConfig" xml:space="preserve">
+    <value>Configuração de Resposta ao Desafio</value>
+  </data>
+  <data name="IdentifierAuthorization_AddAnotherConfig" xml:space="preserve">
+    <value>Se você precisar autorizar vários domínios/identificadores de maneiras diferentes, pode adicionar outra configuração de autorização:</value>
+  </data>
+  <data name="IdentifierAuthorization_AddConfiguration" xml:space="preserve">
+    <value>Adicionar Configuração</value>
+  </data>
+  <data name="ConfigurationTestResults" xml:space="preserve">
+    <value>Resultados do Teste de Configuração</value>
+  </data>
+  <data name="ClickToCopy" xml:space="preserve">
+    <value>Clique para copiar para a área de transferência</value>
+  </data>
 </root>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -747,4 +747,73 @@ for the certification process to work.</value>
   <data name="ManagedCertificateSettings_CertificateAuthority_PreferredChain_Instructions" xml:space="preserve">
     <value> The certificate authority may present multiple versions of your certificate signed with different root (issuer) certificates and you can specify a preference for this certificate. If the exact chain is not available then the default chain will be used.</value>
   </data>
+  <data name="Dashboard_Summary" xml:space="preserve">
+    <value>Summary</value>
+  </data>
+  <data name="Dashboard_ManagedCertificates" xml:space="preserve">
+    <value>Managed Certificates</value>
+  </data>
+  <data name="Dashboard_Healthy" xml:space="preserve">
+    <value>Healthy</value>
+  </data>
+  <data name="Dashboard_Errors" xml:space="preserve">
+    <value>Errors</value>
+  </data>
+  <data name="Dashboard_Warnings" xml:space="preserve">
+    <value>Warnings</value>
+  </data>
+  <data name="Dashboard_AwaitingUser" xml:space="preserve">
+    <value>Awaiting User</value>
+  </data>
+  <data name="Dashboard_TotalDomains" xml:space="preserve">
+    <value>Total Domains</value>
+  </data>
+  <data name="Dashboard_InvalidConfig" xml:space="preserve">
+    <value>Invalid Config</value>
+  </data>
+  <data name="Dashboard_NoCertificate" xml:space="preserve">
+    <value>No Certificate</value>
+  </data>
+  <data name="Preview_Title" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="Preview_Intro" xml:space="preserve">
+    <value>The following is a preview of the actions which will be performed based on these settings:</value>
+  </data>
+  <data name="RunTask" xml:space="preserve">
+    <value>Run Task</value>
+  </data>
+  <data name="StatusLabel" xml:space="preserve">
+    <value>Status: </value>
+  </data>
+  <data name="ManagedCertificates_Tasks_DeploymentTasks" xml:space="preserve">
+    <value>Deployment Tasks</value>
+  </data>
+  <data name="ManagedCertificates_Tasks_PreRequestTasks" xml:space="preserve">
+    <value>Pre-Request Tasks</value>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="IdentifierAuthorization_Title" xml:space="preserve">
+    <value>Identifier Authorization</value>
+  </data>
+  <data name="IdentifierAuthorization_Intro" xml:space="preserve">
+    <value>For a certificate to be issued you must prove control of the domains or other identifiers in your certificate request. For domains, you can choose to validate using HTTP (port 80), or via DNS. If any included identifier fails validation the certificate request cannot be completed.</value>
+  </data>
+  <data name="IdentifierAuthorization_ChallengeConfig" xml:space="preserve">
+    <value>Challenge Response Configuration</value>
+  </data>
+  <data name="IdentifierAuthorization_AddAnotherConfig" xml:space="preserve">
+    <value>If you need to authorize multiple domains/identifiers in different ways you can add another authorization config:</value>
+  </data>
+  <data name="IdentifierAuthorization_AddConfiguration" xml:space="preserve">
+    <value>Add Configuration</value>
+  </data>
+  <data name="ConfigurationTestResults" xml:space="preserve">
+    <value>Configuration Test Results</value>
+  </data>
+  <data name="ClickToCopy" xml:space="preserve">
+    <value>Click to copy to clipboard</value>
+  </data>
 </root>

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/Dashboard.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/Dashboard.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:Resources="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">
@@ -42,7 +43,7 @@
     </UserControl.Resources>
     <StackPanel>
 
-        <GroupBox BorderThickness="0" Header="Summary">
+        <GroupBox BorderThickness="0" Header="{x:Static Resources:SR.Dashboard_Summary}">
             <StackPanel Margin="16,8,0,8" Orientation="Horizontal">
 
                 <StackPanel Width="220">
@@ -50,7 +51,7 @@
 
                         <TextBlock DockPanel.Dock="Left">
                             <Hyperlink Click="Hyperlink_Click" Tag="">
-                                Managed Certificates
+                                <Run Text="{x:Static Resources:SR.Dashboard_ManagedCertificates}" />
                             </Hyperlink>
                         </TextBlock>
                         <Border Background="Black" Style="{StaticResource SummaryBadge}">
@@ -61,7 +62,7 @@
                     <DockPanel x:Name="PanelHealthy" Style="{StaticResource SummaryPanel}">
                         <TextBlock DockPanel.Dock="Left">
                             <Hyperlink Click="Hyperlink_Click" Tag="[Status=OK]">
-                                Healthy
+                                <Run Text="{x:Static Resources:SR.Dashboard_Healthy}" />
                             </Hyperlink>
                         </TextBlock>
                         <Border
@@ -75,7 +76,7 @@
                     <DockPanel x:Name="PanelError" Style="{StaticResource SummaryPanel}">
                         <TextBlock DockPanel.Dock="Left">
                             <Hyperlink Click="Hyperlink_Click" Tag="[Status=Error]">
-                                Errors
+                                <Run Text="{x:Static Resources:SR.Dashboard_Errors}" />
                             </Hyperlink>
                         </TextBlock>
                         <Border
@@ -89,7 +90,7 @@
                     <DockPanel x:Name="PanelWarning" Style="{StaticResource SummaryPanel}">
                         <TextBlock DockPanel.Dock="Left">
                             <Hyperlink Click="Hyperlink_Click" Tag="[Status=Warning]">
-                                Warning
+                                <Run Text="{x:Static Resources:SR.Dashboard_Warnings}" />
                             </Hyperlink>
                         </TextBlock>
                         <Border
@@ -103,7 +104,7 @@
                     <DockPanel x:Name="PanelAwaitingUser" Style="{StaticResource SummaryPanel}">
                         <TextBlock DockPanel.Dock="Left">
                             <Hyperlink Click="Hyperlink_Click" Tag="[Status=AwaitingUser]">
-                                Awaiting User
+                                <Run Text="{x:Static Resources:SR.Dashboard_AwaitingUser}" />
                             </Hyperlink>
                         </TextBlock>
                         <Border
@@ -119,9 +120,7 @@
 
                 <StackPanel Width="120" Margin="64,0,0,0">
                     <DockPanel Style="{StaticResource SummaryPanel}">
-                        <TextBlock DockPanel.Dock="Left">
-                            Total Domains
-                        </TextBlock>
+                        <TextBlock DockPanel.Dock="Left" Text="{x:Static Resources:SR.Dashboard_TotalDomains}" />
                         <Border
                             Background="DarkSlateGray"
                             DockPanel.Dock="Right"
@@ -142,7 +141,7 @@
                         </DockPanel.Style>
                         <TextBlock DockPanel.Dock="Left">
                             <Hyperlink Click="Hyperlink_Click" Tag="[Status=InvalidConfig]">
-                                Invalid Config
+                                <Run Text="{x:Static Resources:SR.Dashboard_InvalidConfig}" />
                             </Hyperlink>
                         </TextBlock>
                         <Border
@@ -166,7 +165,7 @@
                         </DockPanel.Style>
                         <TextBlock DockPanel.Dock="Left">
                             <Hyperlink Click="Hyperlink_Click" Tag="[Status=NoCertificate]">
-                                No Certificate
+                                <Run Text="{x:Static Resources:SR.Dashboard_NoCertificate}" />
                             </Hyperlink>
                         </TextBlock>
                         <Border

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/IdentifiersAuthorization.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/IdentifiersAuthorization.xaml
@@ -32,8 +32,8 @@
 
             <!--  Authorization Types  -->
             <StackPanel Margin="0,0,0,16">
-                <TextBlock Style="{StaticResource Subheading}">Identifier Authorization</TextBlock>
-                <TextBlock Style="{StaticResource Instructions}" Text="For a certificate to be issued you must prove control of the domains or other identifiers in your certificate request. For domains, you can choose to validate using HTTP (port 80), or via DNS. If any included identifier fails validation the certificate request cannot be completed." />
+                <TextBlock Style="{StaticResource Subheading}" Text="{x:Static Resources:SR.IdentifierAuthorization_Title}" />
+                <TextBlock Style="{StaticResource Instructions}" Text="{x:Static Resources:SR.IdentifierAuthorization_Intro}" />
             </StackPanel>
 
             <ItemsControl
@@ -44,7 +44,7 @@
                     <DataTemplate>
                         <StackPanel>
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock Style="{StaticResource Subheading}">Challenge Response Configuration</TextBlock>
+                                <TextBlock Style="{StaticResource Subheading}" Text="{x:Static Resources:SR.IdentifierAuthorization_ChallengeConfig}" />
                                 <TextBlock
                                     Margin="8,0,0,0"
                                     Style="{StaticResource Subheading}"
@@ -60,15 +60,14 @@
 
             <StackPanel>
 
-                <TextBlock Style="{StaticResource Instructions}" Text="If you need to authorize multiple domains/identifiers in different ways you can add another authorization config:" />
+                <TextBlock Style="{StaticResource Instructions}" Text="{x:Static Resources:SR.IdentifierAuthorization_AddAnotherConfig}" />
                 <Button
                     x:Name="AddAuth"
                     MaxWidth="160"
                     Margin="16,8,0,0"
                     HorizontalAlignment="Left"
-                    Click="AddAuth_Click">
-                    Add Configuration
-                </Button>
+                    Click="AddAuth_Click"
+                    Content="{x:Static Resources:SR.IdentifierAuthorization_AddConfiguration}" />
             </StackPanel>
         </StackPanel>
     </ScrollViewer>

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/Preview.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/Preview.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Certify.UI.Controls.ManagedCertificate"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:Resources="clr-namespace:Certify.Locales;assembly=Certify.Locales"
    
     IsVisibleChanged="UserControl_IsVisibleChanged"
     mc:Ignorable="d">
@@ -12,7 +13,7 @@
     <DockPanel Margin="8,0,8,8" LastChildFill="True">
 
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
-            <TextBlock DockPanel.Dock="Top" Style="{StaticResource Subheading}">Preview</TextBlock>
+            <TextBlock DockPanel.Dock="Top" Style="{StaticResource Subheading}" Text="{x:Static Resources:SR.Preview_Title}" />
             <ProgressBar
                 x:Name="LoadingProgess"
                 MinWidth="160"
@@ -25,7 +26,7 @@
             <TextBlock
                 DockPanel.Dock="Top"
                 Style="{StaticResource Instructions}"
-                Text="The following is a preview of the actions which will be performed based on these settings:" />
+                Text="{x:Static Resources:SR.Preview_Intro}" />
 
             <WebBrowser x:Name="MarkdownView" DockPanel.Dock="Top" />
         </DockPanel>

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/TaskList.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/TaskList.xaml
@@ -45,7 +45,7 @@
                             Click="RunDeploymentTask_Click"
                             CommandParameter="{Binding}"
                             DockPanel.Dock="Left"
-                            ToolTip="Run Task">
+                            ToolTip="{x:Static Resources:SR.RunTask}">
                             <StackPanel Orientation="Horizontal">
                                 <fa:ImageAwesome
                                     HorizontalAlignment="Center"
@@ -122,7 +122,7 @@
                                 <TextBlock
                                     FontWeight="SemiBold"
                                     Foreground="{Binding LastRunStatus, Converter={StaticResource StateToColorConverter}}"
-                                    Text="Status: " />
+                                    Text="{x:Static Resources:SR.StatusLabel}" />
                                 <TextBlock
                                     FontWeight="SemiBold"
                                     Foreground="{Binding LastRunStatus, Converter={StaticResource StateToColorConverter}}"

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/Tasks.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/Tasks.xaml
@@ -25,7 +25,7 @@
 
 
             <StackPanel DockPanel.Dock="Top">
-                <TextBlock Margin="0,16,0,0" Style="{StaticResource Subheading}">Deployment Tasks</TextBlock>
+                <TextBlock Margin="0,16,0,0" Style="{StaticResource Subheading}" Text="{x:Static res:SR.ManagedCertificates_Tasks_DeploymentTasks}" />
                 <StackPanel Orientation="Vertical">
                     <TextBlock Style="{StaticResource Instructions}" Text="{x:Static res:SR.ManagedCertificates_Tasks_DeploymentIntro}" />
 
@@ -42,7 +42,7 @@
                                 VerticalAlignment="Center"
                                 Foreground="{DynamicResource MahApps.Brushes.Accent}"
                                 Icon="PlusCircle" />
-                            <TextBlock Margin="8,0,0,0" VerticalAlignment="Center">Add</TextBlock>
+                            <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Text="{x:Static res:SR.Add}" />
                         </StackPanel>
                     </Button>
                 </StackPanel>
@@ -51,7 +51,7 @@
 
             </StackPanel>
             <StackPanel DockPanel.Dock="Top">
-                <TextBlock Margin="0,16,0,0" Style="{StaticResource Subheading}">Pre-Request Tasks</TextBlock>
+                <TextBlock Margin="0,16,0,0" Style="{StaticResource Subheading}" Text="{x:Static res:SR.ManagedCertificates_Tasks_PreRequestTasks}" />
                 <StackPanel Orientation="Vertical">
                     <TextBlock Style="{StaticResource Instructions}" Text="{x:Static res:SR.ManagedCertificates_Tasks_PrerequestIntro}" />
                     <Button
@@ -67,7 +67,7 @@
                                 VerticalAlignment="Center"
                                 Foreground="{DynamicResource MahApps.Brushes.Accent}"
                                 Icon="PlusCircle" />
-                            <TextBlock Margin="8,0,0,0" VerticalAlignment="Center">Add</TextBlock>
+                            <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Text="{x:Static res:SR.Add}" />
                         </StackPanel>
                     </Button>
                 </StackPanel>

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/TestProgress.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/TestProgress.xaml
@@ -9,6 +9,7 @@
     xmlns:local="clr-namespace:Certify.UI.Controls.ManagedCertificate"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:utils="clr-namespace:Certify.UI.Utils"
+    xmlns:Resources="clr-namespace:Certify.Locales;assembly=Certify.Locales"
     d:DataContext="{d:DesignInstance Type=certifyui:ManagedCertificateViewModelDesign,
                                      IsDesignTimeCreatable=True}"
     d:DesignHeight="300"
@@ -30,9 +31,8 @@
             <TextBlock
                 Margin="0,8,0,0"
                 DockPanel.Dock="Top"
-                Style="{StaticResource Subheading}">
-                Configuration Test Results
-            </TextBlock>
+                Style="{StaticResource Subheading}"
+                Text="{x:Static Resources:SR.ConfigurationTestResults}" />
             <Controls:ProgressMonitor Margin="4,0,0,0" DockPanel.Dock="Top" />
             <ItemsControl
                 x:Name="Results"
@@ -67,7 +67,7 @@
                                 Style="{StaticResource Instructions}"
                                 Text="{Binding Path=Message}"
                                 TextWrapping="WrapWithOverflow"
-                                ToolTip="Click to copy to clipboard" />
+                                ToolTip="{x:Static Resources:SR.ClickToCopy}" />
                         </DockPanel>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- replace hard-coded strings in managed certificate controls with resource bindings
- add English and Brazilian Portuguese translations for new keys

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aa0e1f4358832e81a3756719c26aed