### PR TITLE
Translate stored credentials settings UI to Portuguese

### DIFF
--- a/src/Certify.UI.Shared/Controls/Settings/Credentials.xaml
+++ b/src/Certify.UI.Shared/Controls/Settings/Credentials.xaml
@@ -22,14 +22,14 @@
     <DockPanel LastChildFill="True">
 
         <TextBlock DockPanel.Dock="Top" Style="{StaticResource Instructions}">
-            Stored Credentials are saved API Keys or password for providers (DNS etc). Multiple managed sites can re-use the same stored credentials as required. These credentials are stored locally and protected using the Windows Data Protection APIs.
+            Credenciais Armazenadas são chaves de API ou senhas salvas para provedores (DNS etc.). Vários sites gerenciados podem reutilizar as mesmas credenciais armazenadas conforme necessário. Essas credenciais são armazenadas localmente e protegidas usando as APIs de Proteção de Dados do Windows.
         </TextBlock>
         <Button
             x:Name="AddStoredCredential"
             Width="200"
             HorizontalAlignment="Right"
             Click="AddStoredCredential_Click"
-            Content="Add New Stored Credential"
+            Content="Adicionar Nova Credencial Armazenada"
             DockPanel.Dock="Top" />
 
         <StackPanel
@@ -46,7 +46,7 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
                 Click="TestStoredCredential_Click"
-                Content="Test" />
+                Content="Testar" />
             <Button
                 x:Name="ModifyStoredCredential"
                 Width="128"
@@ -54,7 +54,7 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
                 Click="ModifyStoredCredential_Click"
-                Content="Replace" />
+                Content="Substituir" />
             <Button
                 x:Name="DeleteStoredCredential"
                 Width="128"
@@ -62,7 +62,7 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
                 Click="DeleteStoredCredential_Click"
-                Content="Delete" />
+                Content="Excluir" />
         </StackPanel>
 
         <ScrollViewer


### PR DESCRIPTION
## Summary
- localize stored credential descriptions and buttons to Portuguese

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2da724cc832e8263eef1812b99b4