### PR TITLE
Ensure AutoIP DNS provider always sends hostname and txt

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -99,14 +99,18 @@ namespace Certify.Providers.DNS.AutoIP
         {
             try
             {
-                var payload = new Dictionary<string, string>{
-                    { "txt", request.RecordValue }
-                };
-
-                if (!string.IsNullOrEmpty(_hostname))
+                if (string.IsNullOrEmpty(_hostname))
                 {
-                    payload.Add("hostname", _hostname);
+                    var message = "Hostname parameter is required for AutoIP requests.";
+                    _log?.Error(message);
+                    return new ActionResult { IsSuccess = false, Message = message };
                 }
+
+                var payload = new Dictionary<string, string>
+                {
+                    ["txt"] = request.RecordValue,
+                    ["hostname"] = _hostname
+                };
 
                 var json = JsonConvert.SerializeObject(payload);
                 var authInfo = string.IsNullOrEmpty(_password) ? $"token {_credential}" : $"user {_credential} / ****";
@@ -133,13 +137,20 @@ namespace Certify.Providers.DNS.AutoIP
         {
             try
             {
-                var payload = new Dictionary<string, string>();
-                if (!string.IsNullOrEmpty(_hostname))
+                if (string.IsNullOrEmpty(_hostname))
                 {
-                    payload.Add("hostname", _hostname);
+                    var message = "Hostname parameter is required for AutoIP requests.";
+                    _log?.Error(message);
+                    return new ActionResult { IsSuccess = false, Message = message };
                 }
 
-                var json = payload.Count > 0 ? JsonConvert.SerializeObject(payload) : string.Empty;
+                var payload = new Dictionary<string, string>
+                {
+                    ["txt"] = request.RecordValue,
+                    ["hostname"] = _hostname
+                };
+
+                var json = JsonConvert.SerializeObject(payload);
                 var authInfo = string.IsNullOrEmpty(_password) ? $"token {_credential}" : $"user {_credential} / ****";
                 _log?.Information("HTTP DELETE {Url} Payload: {Payload}. Auth: {AuthInfo}", _apiEndpoint, json, authInfo);
                 var req = new HttpRequestMessage(HttpMethod.Delete, _apiEndpoint)

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
@@ -53,11 +53,12 @@ namespace Certify.Core.Tests.Unit
             Assert.AreEqual(2, createJson.Count);
             Assert.IsTrue(createResult.IsSuccess);
 
-            var deleteResult = await provider.DeleteRecord(new DnsRecord());
+            var deleteResult = await provider.DeleteRecord(new DnsRecord { RecordValue = "txtvalue" });
             var deleteContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
             var deleteJson = JObject.Parse(deleteContent);
+            Assert.AreEqual("txtvalue", deleteJson["txt"]!.ToString());
             Assert.AreEqual("test.example.com", deleteJson["hostname"]!.ToString());
-            Assert.AreEqual(1, deleteJson.Count);
+            Assert.AreEqual(2, deleteJson.Count);
             Assert.IsTrue(deleteResult.IsSuccess);
         }
 
@@ -69,16 +70,45 @@ namespace Certify.Core.Tests.Unit
                 new Dictionary<string, string>());
 
             var createResult = await provider.CreateRecord(new DnsRecord { RecordValue = "txtvalue" });
-            var createContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
-            var createJson = JObject.Parse(createContent);
-            Assert.AreEqual("txtvalue", createJson["txt"]!.ToString());
-            Assert.AreEqual(1, createJson.Count);
-            Assert.IsTrue(createResult.IsSuccess);
+            Assert.IsFalse(createResult.IsSuccess);
+            Assert.IsNull(handler.LastRequest);
 
-            var deleteResult = await provider.DeleteRecord(new DnsRecord());
-            var deleteContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
-            Assert.AreEqual(string.Empty, deleteContent);
-            Assert.IsTrue(deleteResult.IsSuccess);
+            var deleteResult = await provider.DeleteRecord(new DnsRecord { RecordValue = "txtvalue" });
+            Assert.IsFalse(deleteResult.IsSuccess);
+            Assert.IsNull(handler.LastRequest);
+        }
+
+        [TestMethod]
+        public async Task CreateAndDelete_MultipleHosts_SendsCorrectPayloads()
+        {
+            var (provider, handler) = await SetupAsync(
+                new Dictionary<string, string> { ["acmetoken"] = "token" },
+                new Dictionary<string, string> { ["hostname"] = "host0.example.com" });
+
+            var hostnameField = typeof(DnsProviderAutoIP).GetField("_hostname", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var hosts = new[] { "host1.example.com", "host2.example.com" };
+
+            for (var i = 0; i < hosts.Length; i++)
+            {
+                hostnameField.SetValue(provider, hosts[i]);
+
+                var txt = $"txt{i}";
+                var createResult = await provider.CreateRecord(new DnsRecord { RecordValue = txt });
+                var createContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
+                var createJson = JObject.Parse(createContent);
+                Assert.AreEqual(txt, createJson["txt"]!.ToString());
+                Assert.AreEqual(hosts[i], createJson["hostname"]!.ToString());
+                Assert.AreEqual(2, createJson.Count);
+                Assert.IsTrue(createResult.IsSuccess);
+
+                var deleteResult = await provider.DeleteRecord(new DnsRecord { RecordValue = txt });
+                var deleteContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
+                var deleteJson = JObject.Parse(deleteContent);
+                Assert.AreEqual(txt, deleteJson["txt"]!.ToString());
+                Assert.AreEqual(hosts[i], deleteJson["hostname"]!.ToString());
+                Assert.AreEqual(2, deleteJson.Count);
+                Assert.IsTrue(deleteResult.IsSuccess);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Include `hostname` and `txt` in all AutoIP DNS requests
- Require hostname parameter and skip HTTP calls when missing
- Cover multiple hostnames per certificate in unit tests

## Testing
- `dotnet test src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7627b394832eb103611fd5d8438b