### PR TITLE
Handle per-request hostname for AutoIP provider

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -99,6 +99,8 @@ namespace Certify.Providers.DNS.AutoIP
         {
             try
             {
+                _hostname = request?.RecordName ?? request?.TargetDomainName ?? _hostname;
+
                 if (string.IsNullOrEmpty(_hostname))
                 {
                     var message = "Hostname parameter is required for AutoIP requests.";
@@ -137,6 +139,8 @@ namespace Certify.Providers.DNS.AutoIP
         {
             try
             {
+                _hostname = request?.RecordName ?? request?.TargetDomainName ?? _hostname;
+
                 if (string.IsNullOrEmpty(_hostname))
                 {
                     var message = "Hostname parameter is required for AutoIP requests.";

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
@@ -83,17 +83,14 @@ namespace Certify.Core.Tests.Unit
         {
             var (provider, handler) = await SetupAsync(
                 new Dictionary<string, string> { ["acmetoken"] = "token" },
-                new Dictionary<string, string> { ["hostname"] = "host0.example.com" });
+                new Dictionary<string, string>());
 
-            var hostnameField = typeof(DnsProviderAutoIP).GetField("_hostname", BindingFlags.NonPublic | BindingFlags.Instance)!;
             var hosts = new[] { "host1.example.com", "host2.example.com" };
 
             for (var i = 0; i < hosts.Length; i++)
             {
-                hostnameField.SetValue(provider, hosts[i]);
-
                 var txt = $"txt{i}";
-                var createResult = await provider.CreateRecord(new DnsRecord { RecordValue = txt });
+                var createResult = await provider.CreateRecord(new DnsRecord { RecordName = hosts[i], RecordValue = txt });
                 var createContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
                 var createJson = JObject.Parse(createContent);
                 Assert.AreEqual(txt, createJson["txt"]!.ToString());
@@ -101,7 +98,7 @@ namespace Certify.Core.Tests.Unit
                 Assert.AreEqual(2, createJson.Count);
                 Assert.IsTrue(createResult.IsSuccess);
 
-                var deleteResult = await provider.DeleteRecord(new DnsRecord { RecordValue = txt });
+                var deleteResult = await provider.DeleteRecord(new DnsRecord { RecordName = hosts[i], RecordValue = txt });
                 var deleteContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
                 var deleteJson = JObject.Parse(deleteContent);
                 Assert.AreEqual(txt, deleteJson["txt"]!.ToString());


### PR DESCRIPTION
## Summary
- derive AutoIP hostname from each DNS record request
- add DNS provider tests for multiple per-request hostnames

## Testing
- `dotnet test src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj --filter DnsProviderAutoIP --nologo` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab79a55878832ea625c93dc0bf72bd