### PR TITLE
Use identifier domain for AutoIP DNS hostname

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -99,9 +99,9 @@ namespace Certify.Providers.DNS.AutoIP
         {
             try
             {
-                _hostname = request?.RecordName ?? request?.TargetDomainName ?? _hostname;
+                var hostname = request?.TargetDomainName ?? _hostname;
 
-                if (string.IsNullOrEmpty(_hostname))
+                if (string.IsNullOrEmpty(hostname))
                 {
                     var message = "Hostname parameter is required for AutoIP requests.";
                     _log?.Error(message);
@@ -111,7 +111,7 @@ namespace Certify.Providers.DNS.AutoIP
                 var payload = new Dictionary<string, string>
                 {
                     ["txt"] = request.RecordValue,
-                    ["hostname"] = _hostname
+                    ["hostname"] = hostname
                 };
 
                 var json = JsonConvert.SerializeObject(payload);
@@ -139,9 +139,9 @@ namespace Certify.Providers.DNS.AutoIP
         {
             try
             {
-                _hostname = request?.RecordName ?? request?.TargetDomainName ?? _hostname;
+                var hostname = request?.TargetDomainName ?? _hostname;
 
-                if (string.IsNullOrEmpty(_hostname))
+                if (string.IsNullOrEmpty(hostname))
                 {
                     var message = "Hostname parameter is required for AutoIP requests.";
                     _log?.Error(message);
@@ -151,7 +151,7 @@ namespace Certify.Providers.DNS.AutoIP
                 var payload = new Dictionary<string, string>
                 {
                     ["txt"] = request.RecordValue,
-                    ["hostname"] = _hostname
+                    ["hostname"] = hostname
                 };
 
                 var json = JsonConvert.SerializeObject(payload);

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
@@ -79,7 +79,7 @@ namespace Certify.Core.Tests.Unit
         }
 
         [TestMethod]
-        public async Task CreateAndDelete_MultipleHosts_SendsCorrectPayloads()
+        public async Task CreateAndDelete_AcmeFqdn_UsesTargetDomainName()
         {
             var (provider, handler) = await SetupAsync(
                 new Dictionary<string, string> { ["acmetoken"] = "token" },
@@ -89,20 +89,25 @@ namespace Certify.Core.Tests.Unit
 
             for (var i = 0; i < hosts.Length; i++)
             {
+                var baseDomain = hosts[i];
+                var fqdn = $"_acme-challenge.{baseDomain}";
                 var txt = $"txt{i}";
-                var createResult = await provider.CreateRecord(new DnsRecord { RecordName = hosts[i], RecordValue = txt });
+
+                var record = new DnsRecord { RecordName = fqdn, TargetDomainName = baseDomain, RecordValue = txt };
+
+                var createResult = await provider.CreateRecord(record);
                 var createContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
                 var createJson = JObject.Parse(createContent);
                 Assert.AreEqual(txt, createJson["txt"]!.ToString());
-                Assert.AreEqual(hosts[i], createJson["hostname"]!.ToString());
+                Assert.AreEqual(baseDomain, createJson["hostname"]!.ToString());
                 Assert.AreEqual(2, createJson.Count);
                 Assert.IsTrue(createResult.IsSuccess);
 
-                var deleteResult = await provider.DeleteRecord(new DnsRecord { RecordName = hosts[i], RecordValue = txt });
+                var deleteResult = await provider.DeleteRecord(record);
                 var deleteContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
                 var deleteJson = JObject.Parse(deleteContent);
                 Assert.AreEqual(txt, deleteJson["txt"]!.ToString());
-                Assert.AreEqual(hosts[i], deleteJson["hostname"]!.ToString());
+                Assert.AreEqual(baseDomain, deleteJson["hostname"]!.ToString());
                 Assert.AreEqual(2, deleteJson.Count);
                 Assert.IsTrue(deleteResult.IsSuccess);
             }


### PR DESCRIPTION
## Summary
- prioritize TargetDomainName over RecordName when setting hostname for AutoIP DNS API
- always include identifier domain in AutoIP DNS payload
- add tests covering ACME challenge FQDN using TargetDomainName

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8171079c832e9a9f77945882a51f