### PR TITLE
Trim TargetDomainName for DNS record deletion

### DIFF
--- a/src/Certify.Core/Management/Challenges/DNS/DnsChallengeHelper.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsChallengeHelper.cs
@@ -436,7 +436,7 @@ namespace Certify.Core.Management.Challenges
                     var result = await dnsAPIProvider.DeleteRecord(new DnsRecord
                     {
                         RecordType = "TXT",
-                        TargetDomainName = domain.Value,
+                        TargetDomainName = domain.Value.Trim(),
                         RecordName = txtRecordName,
                         RecordValue = txtRecordValue,
                         ZoneId = zoneId


### PR DESCRIPTION
## Summary
- ensure TargetDomainName is trimmed when deleting DNS TXT records

## Testing
- `dotnet test src/Certify.Core.Service.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8631a9e8832ea0ffb2e56cde7d1b