### PR TITLE
Include null values in AutoIP payload logging

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -114,7 +114,10 @@ namespace Certify.Providers.DNS.AutoIP
                     ["hostname"] = hostname
                 };
 
-                var json = JsonConvert.SerializeObject(payload);
+                var json = JsonConvert.SerializeObject(payload, new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Include
+                });
                 var authInfo = string.IsNullOrEmpty(_password) ? $"token {_credential}" : $"user {_credential} / ****";
                 _log?.Information("HTTP POST {Url} Payload: {Payload}. Auth: {AuthInfo}", _apiEndpoint, json, authInfo);
                 var resp = await _http.PostAsync(_apiEndpoint, new StringContent(json, Encoding.UTF8, "application/json"));
@@ -154,7 +157,10 @@ namespace Certify.Providers.DNS.AutoIP
                     ["hostname"] = hostname
                 };
 
-                var json = JsonConvert.SerializeObject(payload);
+                var json = JsonConvert.SerializeObject(payload, new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Include
+                });
                 var authInfo = string.IsNullOrEmpty(_password) ? $"token {_credential}" : $"user {_credential} / ****";
                 _log?.Information("HTTP DELETE {Url} Payload: {Payload}. Auth: {AuthInfo}", _apiEndpoint, json, authInfo);
                 var req = new HttpRequestMessage(HttpMethod.Delete, _apiEndpoint)


### PR DESCRIPTION
## Summary
- ensure null values like hostname are included when serializing AutoIP payloads

## Testing
- `dotnet test src/Certify.Core.Service.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab890e3650832eb4fcdd6e444114cf