### PR TITLE
Aplique Trim e log em AutoIP provider

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -99,7 +99,7 @@ namespace Certify.Providers.DNS.AutoIP
         {
             try
             {
-                var hostname = request?.TargetDomainName ?? _hostname;
+                var hostname = (request?.TargetDomainName ?? _hostname)?.Trim();
 
                 if (string.IsNullOrEmpty(hostname))
                 {
@@ -107,6 +107,8 @@ namespace Certify.Providers.DNS.AutoIP
                     _log?.Error(message);
                     return new ActionResult { IsSuccess = false, Message = message };
                 }
+
+                _log?.Debug("AutoIP CreateRecord using hostname: {Hostname}", hostname);
 
                 var payload = new Dictionary<string, string>
                 {
@@ -139,7 +141,7 @@ namespace Certify.Providers.DNS.AutoIP
         {
             try
             {
-                var hostname = request?.TargetDomainName ?? _hostname;
+                var hostname = (request?.TargetDomainName ?? _hostname)?.Trim();
 
                 if (string.IsNullOrEmpty(hostname))
                 {
@@ -147,6 +149,8 @@ namespace Certify.Providers.DNS.AutoIP
                     _log?.Error(message);
                     return new ActionResult { IsSuccess = false, Message = message };
                 }
+
+                _log?.Debug("AutoIP DeleteRecord using hostname: {Hostname}", hostname);
 
                 var payload = new Dictionary<string, string>
                 {


### PR DESCRIPTION
## Summary
- Aplica .Trim() ao hostname recebido e registra hostname final com `_log?.Debug` antes da serialização do payload

## Testing
- `dotnet test src/Certify.Core.Service.sln` *(falhou: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8902e86c832ea12d458c0201dd3a