### PR TITLE
feat: support hostname from credentials

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -67,6 +67,10 @@ namespace Certify.Providers.DNS.AutoIP
             }
             credentials?.TryGetValue("password", out _password);
             parameters?.TryGetValue("hostname", out _hostname);
+            if (string.IsNullOrEmpty(_hostname))
+            {
+                credentials?.TryGetValue("hostname", out _hostname);
+            }
             parameters?.TryGetValue("apiendpoint", out _apiEndpoint);
 
             if (parameters?.ContainsKey("propagationdelay") == true && int.TryParse(parameters["propagationdelay"], out var delay))

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsProviderAutoIPTests.cs
@@ -45,6 +45,36 @@ namespace Certify.Core.Tests.Unit
                 new Dictionary<string, string> { ["acmetoken"] = "token" },
                 new Dictionary<string, string> { ["hostname"] = "test.example.com" });
 
+            var hostnameField = typeof(DnsProviderAutoIP).GetField("_hostname", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.AreEqual("test.example.com", hostnameField!.GetValue(provider) as string);
+
+            var createResult = await provider.CreateRecord(new DnsRecord { RecordValue = "txtvalue" });
+            var createContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
+            var createJson = JObject.Parse(createContent);
+            Assert.AreEqual("txtvalue", createJson["txt"]!.ToString());
+            Assert.AreEqual("test.example.com", createJson["hostname"]!.ToString());
+            Assert.AreEqual(2, createJson.Count);
+            Assert.IsTrue(createResult.IsSuccess);
+
+            var deleteResult = await provider.DeleteRecord(new DnsRecord { RecordValue = "txtvalue" });
+            var deleteContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
+            var deleteJson = JObject.Parse(deleteContent);
+            Assert.AreEqual("txtvalue", deleteJson["txt"]!.ToString());
+            Assert.AreEqual("test.example.com", deleteJson["hostname"]!.ToString());
+            Assert.AreEqual(2, deleteJson.Count);
+            Assert.IsTrue(deleteResult.IsSuccess);
+        }
+
+        [TestMethod]
+        public async Task CreateAndDelete_WithTokenAndHostname_InCredentials()
+        {
+            var (provider, handler) = await SetupAsync(
+                new Dictionary<string, string> { ["acmetoken"] = "token", ["hostname"] = "test.example.com" },
+                new Dictionary<string, string>());
+
+            var hostnameField = typeof(DnsProviderAutoIP).GetField("_hostname", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.AreEqual("test.example.com", hostnameField!.GetValue(provider) as string);
+
             var createResult = await provider.CreateRecord(new DnsRecord { RecordValue = "txtvalue" });
             var createContent = await handler.LastRequest!.Content!.ReadAsStringAsync();
             var createJson = JObject.Parse(createContent);


### PR DESCRIPTION
## Summary
- allow AutoIP provider to read hostname from credentials when not specified in parameters
- test that hostname can be sourced from either parameters or credentials

## Testing
- `dotnet test src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab92c52870832e9620ccc6c6569d99