### PR TITLE
style: add spacing around credential handling

### DIFF
--- a/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
+++ b/src/Certify.Providers/DNS/AutoIP/DnsProviderAutoIP.cs
@@ -65,6 +65,7 @@ namespace Certify.Providers.DNS.AutoIP
             {
                 credentials?.TryGetValue("acmetoken", out _credential);
             }
+
             credentials?.TryGetValue("password", out _password);
             parameters?.TryGetValue("hostname", out _hostname);
             if (string.IsNullOrEmpty(_hostname))
@@ -91,6 +92,7 @@ namespace Certify.Providers.DNS.AutoIP
                     _http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", auth);
                 }
             }
+
             var authType = string.IsNullOrEmpty(_password) ? "token" : "user";
             var passwordDisplay = string.IsNullOrEmpty(_password) ? string.Empty : "****";
             _log?.Information("AutoIP provider initialized. Endpoint: {Endpoint}. AuthType: {AuthType}. Credential: {Credential} {Password}",


### PR DESCRIPTION
## Summary
- improve readability by adding blank lines around credential handling in AutoIP provider

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab941c9a7c832eaa7fbd46427da0e3