### PR TITLE
feat: defer dns cleanup until post-validation

### DIFF
--- a/src/Certify.Core/Management/CertifyManager/CertifyManager.CertificateRequest.cs
+++ b/src/Certify.Core/Management/CertifyManager/CertifyManager.CertificateRequest.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Certify.Core.Management;
+using Certify.Core.Management.Challenges;
 using Certify.Locales;
 using Certify.Models;
 using Certify.Models.Providers;
@@ -760,7 +761,7 @@ namespace Certify.Management
 
             var validationFailed = false;
             var failureSummaryMessage = "";
-            var cleanupChallengesLast = CoreAppSettings.Current.PerformChallengeCleanupsLast;
+            var cleanupChallengesLast = CoreAppSettings.Current.ChallengeCleanupMode == ChallengeCleanupMode.PostValidation;
 
             if (pendingOrder.IsPendingAuthorizations)
             {
@@ -921,6 +922,8 @@ namespace Certify.Management
                                 await authCleanup.Cleanup();
                             }
                         }
+
+                        await DnsChallengeHelper.ProcessPendingDeletes(log);
                     }
                 }
             }

--- a/src/Certify.Core/Management/CertifyManager/CertifyManager.ManagedChallenges.cs
+++ b/src/Certify.Core/Management/CertifyManager/CertifyManager.ManagedChallenges.cs
@@ -248,6 +248,8 @@ namespace Certify.Management
                     log.Information($"DNS: {dnsResult.Result.Message}");
                 }
 
+                await DnsChallengeHelper.ProcessPendingDeletes(log);
+
                 return new ActionResult { IsSuccess = true, Message = $"Challenge cleanup {request.ChallengeType} completed {request.ResponseKey} : {request.ResponseValue}" };
 
             }

--- a/src/Certify.Core/Management/Challenges/ChallengeResponseService.cs
+++ b/src/Certify.Core/Management/Challenges/ChallengeResponseService.cs
@@ -241,6 +241,8 @@ namespace Certify.Core.Management.Challenges
                         await ga.Cleanup();
                     }
                 }
+
+                await DnsChallengeHelper.ProcessPendingDeletes(log);
             }
 
             return results;

--- a/src/Certify.Core/Management/Challenges/DNS/DnsChallengeHelper.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsChallengeHelper.cs
@@ -431,35 +431,95 @@ namespace Certify.Core.Management.Challenges
                 }
 
                 log.Information($"DNS: Deleting TXT Record '{txtRecordName}' :'{txtRecordValue}', [{domain.Value}] {(zoneId != null ? $"in ZoneId '{zoneId}'" : "")} using API provider '{dnsAPIProvider.ProviderTitle}'");
-                try
+
+                var cleanupMode = CoreAppSettings.Current.ChallengeCleanupMode;
+                if (cleanupMode == ChallengeCleanupMode.PostValidation)
                 {
-                    var result = await dnsAPIProvider.DeleteRecord(new DnsRecord
+                    var record = new DnsRecord
                     {
                         RecordType = "TXT",
                         TargetDomainName = domain.Value.Trim(),
                         RecordName = txtRecordName,
                         RecordValue = txtRecordValue,
                         ZoneId = zoneId
-                    });
+                    };
 
-                    result.Message = $"{dnsAPIProvider.ProviderTitle} :: {result.Message}";
+                    var providerKey = challengeConfig.ChallengeProvider + (challengeConfig.ChallengeProvider + JsonConvert.SerializeObject(credentials ?? new Dictionary<string, string>()) + JsonConvert.SerializeObject(parameters ?? new Dictionary<string, string>())).GetHashCode().ToString();
+
+                    if (!_pendingDeletions.ContainsKey(providerKey))
+                    {
+                        _pendingDeletions[providerKey] = new PendingDeletion { Provider = dnsAPIProvider, Records = new List<DnsRecord>() };
+                    }
+
+                    _pendingDeletions[providerKey].Records.Add(record);
 
                     return new DnsChallengeHelperResult
                     {
-                        Result = result,
-                        PropagationSeconds = dnsAPIProvider.PropagationDelaySeconds,
-                        IsAwaitingUser = challengeConfig.ChallengeProvider.Contains(".Manual")
+                        Result = new ActionResult { IsSuccess = true, Message = "DNS record queued for cleanup" },
+                        PropagationSeconds = 0,
+                        IsAwaitingUser = false
                     };
                 }
-                catch (Exception exp)
+                else
                 {
-                    return new DnsChallengeHelperResult(failureMsg: $"Failed [{dnsAPIProvider.ProviderTitle}]: {exp.Message}");
+                    try
+                    {
+                        var result = await dnsAPIProvider.DeleteRecord(new DnsRecord
+                        {
+                            RecordType = "TXT",
+                            TargetDomainName = domain.Value.Trim(),
+                            RecordName = txtRecordName,
+                            RecordValue = txtRecordValue,
+                            ZoneId = zoneId
+                        });
+
+                        result.Message = $"{dnsAPIProvider.ProviderTitle} :: {result.Message}";
+
+                        return new DnsChallengeHelperResult
+                        {
+                            Result = result,
+                            PropagationSeconds = dnsAPIProvider.PropagationDelaySeconds,
+                            IsAwaitingUser = challengeConfig.ChallengeProvider.Contains(".Manual")
+                        };
+                    }
+                    catch (Exception exp)
+                    {
+                        return new DnsChallengeHelperResult(failureMsg: $"Failed [{dnsAPIProvider.ProviderTitle}]: {exp.Message}");
+                    }
                 }
             }
             else
             {
                 return new DnsChallengeHelperResult(failureMsg: "Error: Could not determine DNS API Provider.");
             }
+        }
+
+        private class PendingDeletion
+        {
+            public IDnsProvider Provider { get; set; }
+            public List<DnsRecord> Records { get; set; } = new List<DnsRecord>();
+        }
+
+        private static readonly Dictionary<string, PendingDeletion> _pendingDeletions = new Dictionary<string, PendingDeletion>();
+
+        public static async Task ProcessPendingDeletes(ILog log)
+        {
+            foreach (var pd in _pendingDeletions.Values)
+            {
+                foreach (var r in pd.Records)
+                {
+                    try
+                    {
+                        var result = await pd.Provider.DeleteRecord(r);
+                        log?.Information(result?.Message);
+                    }
+                    catch (Exception exp)
+                    {
+                        log?.Error(exp, "Failed to delete DNS record {record}", r.RecordName);
+                    }
+                }
+            }
+            _pendingDeletions.Clear();
         }
     }
 }

--- a/src/Certify.Core/Management/SettingsManager.cs
+++ b/src/Certify.Core/Management/SettingsManager.cs
@@ -37,6 +37,7 @@ namespace Certify.Management
             UseModernPFXAlgs = false;
             NtpServer = "pool.ntp.org";
             CertificateManagers = new List<CertificateManagerPreference>();
+            ChallengeCleanupMode = ChallengeCleanupMode.Immediate;
         }
 
         public static CoreAppSettings Current
@@ -178,9 +179,9 @@ namespace Certify.Management
         public bool EnableIssuerCache { get; set; }
 
         /// <summary>
-        /// If true, challenge cleanup will only happen after all auth challenges in an order have been processed
+        /// Specifies when challenge cleanup should occur
         /// </summary>
-        public bool PerformChallengeCleanupsLast { get; set; }
+        public ChallengeCleanupMode ChallengeCleanupMode { get; set; }
         public string CurrentServiceVersion { get; set; }
 
         /// <summary>
@@ -210,6 +211,7 @@ namespace Certify.Management
             CoreAppSettings.Current.EnableHttpChallengeServer = prefs.EnableHttpChallengeServer;
             CoreAppSettings.Current.EnableCertificateCleanup = prefs.EnableCertificateCleanup;
             CoreAppSettings.Current.DefaultCertificateStore = prefs.DefaultCertificateStore;
+            CoreAppSettings.Current.ChallengeCleanupMode = prefs.ChallengeCleanupMode;
 
             CoreAppSettings.Current.DefaultCertificateAuthority = prefs.DefaultCertificateAuthority;
             CoreAppSettings.Current.EnableAutomaticCAFailover = prefs.EnableAutomaticCAFailover;
@@ -274,6 +276,7 @@ namespace Certify.Management
                 DefaultCertificateStore = CoreAppSettings.Current.DefaultCertificateStore,
                 EnableStatusReporting = CoreAppSettings.Current.EnableStatusReporting,
                 CertificateCleanupMode = CoreAppSettings.Current.CertificateCleanupMode,
+                ChallengeCleanupMode = CoreAppSettings.Current.ChallengeCleanupMode,
                 DefaultCertificateAuthority = CoreAppSettings.Current.DefaultCertificateAuthority,
                 DefaultKeyCredentials = CoreAppSettings.Current.DefaultKeyCredentials,
                 EnableAutomaticCAFailover = CoreAppSettings.Current.EnableAutomaticCAFailover,

--- a/src/Certify.Models/Config/Preferences.cs
+++ b/src/Certify.Models/Config/Preferences.cs
@@ -20,6 +20,12 @@ namespace Certify.Models
         FullCleanup = 3
     }
 
+    public enum ChallengeCleanupMode
+    {
+        Immediate = 0,
+        PostValidation = 1
+    }
+
     public static class RenewalIntervalModes
     {
         /// <summary>
@@ -68,6 +74,8 @@ namespace Certify.Models
         public bool EnableCertificateCleanup { get; set; } = true;
 
         public CertificateCleanupMode? CertificateCleanupMode { get; set; }
+
+        public ChallengeCleanupMode ChallengeCleanupMode { get; set; } = ChallengeCleanupMode.Immediate;
 
         public string? DefaultCertificateStore { get; set; }
 

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsCleanupTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsCleanupTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Certify.Core.Management.Challenges;
+using Certify.Management;
+using Certify.Models;
+using Certify.Models.Config;
+using Certify.Models.Providers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Certify.Core.Tests.Unit
+{
+    [TestClass]
+    public class DnsCleanupTests
+    {
+        private const string MockProviderId = "DNS01.Mock";
+
+        class MockDnsProvider : IDnsProvider
+        {
+            public static int DeleteCount = 0;
+            public Task<bool> InitProvider(Dictionary<string, string> credentials, Dictionary<string, string> parameters, ILog log = null) => Task.FromResult(true);
+            public Task<ActionResult> Test() => Task.FromResult(new ActionResult { IsSuccess = true });
+            public Task<ActionResult> CreateRecord(DnsRecord request) => Task.FromResult(new ActionResult { IsSuccess = true });
+            public Task<ActionResult> DeleteRecord(DnsRecord request)
+            {
+                DeleteCount++;
+                return Task.FromResult(new ActionResult { IsSuccess = true });
+            }
+            public Task<List<DnsZone>> GetZones() => Task.FromResult(new List<DnsZone>());
+            public int PropagationDelaySeconds => 0;
+            public string ProviderId => MockProviderId;
+            public string ProviderTitle => "Mock DNS";
+            public string ProviderDescription => "";
+            public string ProviderHelpUrl => "";
+            public bool IsTestModeSupported => true;
+            public List<ProviderParameter> ProviderParameters => new List<ProviderParameter>();
+        }
+
+        class MockDnsProviderPlugin : IDnsProviderProviderPlugin
+        {
+            public IDnsProvider GetProvider(Type pluginType, string id) => id == MockProviderId ? new MockDnsProvider() : null;
+            public IEnumerable<ChallengeProviderDefinition> GetProviders(Type pluginType) => new List<ChallengeProviderDefinition>
+            {
+                new ChallengeProviderDefinition
+                {
+                    Id = MockProviderId,
+                    Title = "Mock DNS",
+                    Description = "Mock",
+                    ChallengeType = SupportedChallengeTypes.CHALLENGE_TYPE_DNS,
+                    HandlerType = ChallengeHandlerType.INTERNAL,
+                    ProviderParameters = new List<ProviderParameter>()
+                }
+            };
+        }
+
+        [TestMethod]
+        public async Task DeletesQueuedUntilFlush()
+        {
+            var pluginManager = PluginManager.CurrentInstance ?? new PluginManager();
+            pluginManager.DnsProviderProviders ??= new List<IDnsProviderProviderPlugin>();
+            pluginManager.DnsProviderProviders.Add(new MockDnsProviderPlugin());
+
+            var credentialsManager = new Certify.Datastore.SQLite.SQLiteCredentialStore("Tests\\credentials");
+            var dnsHelper = new DnsChallengeHelper(credentialsManager);
+
+            CoreAppSettings.Current.ChallengeCleanupMode = ChallengeCleanupMode.PostValidation;
+
+            var mc = new ManagedCertificate
+            {
+                RequestConfig = new CertRequestConfig
+                {
+                    Challenges = new ObservableCollection<CertRequestChallengeConfig>
+                    {
+                        new CertRequestChallengeConfig
+                        {
+                            ChallengeType = SupportedChallengeTypes.CHALLENGE_TYPE_DNS,
+                            ChallengeProvider = MockProviderId
+                        }
+                    }
+                }
+            };
+
+            var log = new Models.Loggy(null);
+
+            var d1 = new CertIdentifierItem { IdentifierType = CertIdentifierType.Dns, Value = "one.example.com" };
+            var d2 = new CertIdentifierItem { IdentifierType = CertIdentifierType.Dns, Value = "two.example.com" };
+
+            await dnsHelper.DeleteDNSChallenge(log, mc, d1, "_acme-challenge.one.example.com", "value1");
+            await dnsHelper.DeleteDNSChallenge(log, mc, d2, "_acme-challenge.two.example.com", "value2");
+
+            Assert.AreEqual(0, MockDnsProvider.DeleteCount);
+
+            await DnsChallengeHelper.ProcessPendingDeletes(log);
+
+            Assert.AreEqual(2, MockDnsProvider.DeleteCount);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- queue DNS challenge records for batch cleanup and add configurable cleanup mode
- provide optional post-validation cleanup workflow
- test DNS record deletion is deferred until cleanup flush

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9a1927e0832eacffc94b516d9a3d