### PR TITLE
Avoid language change message when tab switching

### DIFF
--- a/src/Certify.UI.Shared/Controls/Settings/General.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/Settings/General.xaml.cs
@@ -243,16 +243,16 @@ namespace Certify.UI.Controls.Settings
 
         private void CultureSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (CultureSelector.SelectedValue != null)
+            if (!EditModel.SettingsInitialised) return;
+            var cultureID = CultureSelector.SelectedValue?.ToString();
+            if (cultureID == EditModel.MainViewModel.UISettings?.PreferredUICulture) return;
+
+            if (!string.IsNullOrEmpty(cultureID))
             {
                 try
                 {
-                    var cultureID = CultureSelector.SelectedValue?.ToString();
-                    if (!string.IsNullOrEmpty(cultureID))
-                    {
-                        ((ICertifyApp)Application.Current).ChangeCulture(cultureID, true);
-                        EditModel.MainViewModel.UISettings.PreferredUICulture = cultureID;
-                    }
+                    ((ICertifyApp)Application.Current).ChangeCulture(cultureID, true);
+                    EditModel.MainViewModel.UISettings.PreferredUICulture = cultureID;
                 }
                 catch
                 {


### PR DESCRIPTION
## Summary
- only invoke UI language change when a new culture is selected

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abb19eab80832ea77b41fd1e80dfb5