### PR TITLE
Localize Edit Server Connection dialog

### DIFF
--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -765,4 +765,28 @@
   <data name="ClickToCopy" xml:space="preserve">
     <value>Clique para copiar para a área de transferência</value>
   </data>
+  <data name="EditServerConnection_Title" xml:space="preserve">
+    <value>Editar conexão do servidor</value>
+  </data>
+  <data name="EditServerConnection_Instruction" xml:space="preserve">
+    <value>Por padrão, uma API de serviço será vinculada a localhost:9696. Configuração adicional é necessária para conexão remota (IP vinculado, habilitar HTTPS, regras de firewall etc.).</value>
+  </data>
+  <data name="EditServerConnection_ConnectionName" xml:space="preserve">
+    <value>Nome da conexão</value>
+  </data>
+  <data name="EditServerConnection_HostnameOrIP" xml:space="preserve">
+    <value>Nome do host ou IP</value>
+  </data>
+  <data name="EditServerConnection_Port" xml:space="preserve">
+    <value>Porta</value>
+  </data>
+  <data name="EditServerConnection_UseHTTPS" xml:space="preserve">
+    <value>Usar HTTPS</value>
+  </data>
+  <data name="EditServerConnection_AllowUntrustedTLS" xml:space="preserve">
+    <value>Permitir TLS não confiável</value>
+  </data>
+  <data name="EditServerConnection_UseAsDefault" xml:space="preserve">
+    <value>Usar como padrão</value>
+  </data>
 </root>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -816,4 +816,28 @@ for the certification process to work.</value>
   <data name="ClickToCopy" xml:space="preserve">
     <value>Click to copy to clipboard</value>
   </data>
+  <data name="EditServerConnection_Title" xml:space="preserve">
+    <value>Edit Server Connection</value>
+  </data>
+  <data name="EditServerConnection_Instruction" xml:space="preserve">
+    <value>By default a service API will be bound to localhost:9696. Additional service configuration is required for remote connection (bound IP, enabling https, firewall rules etc).</value>
+  </data>
+  <data name="EditServerConnection_ConnectionName" xml:space="preserve">
+    <value>Connection Name</value>
+  </data>
+  <data name="EditServerConnection_HostnameOrIP" xml:space="preserve">
+    <value>Hostname or IP</value>
+  </data>
+  <data name="EditServerConnection_Port" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="EditServerConnection_UseHTTPS" xml:space="preserve">
+    <value>Use Https</value>
+  </data>
+  <data name="EditServerConnection_AllowUntrustedTLS" xml:space="preserve">
+    <value>Allow Untrusted TLS</value>
+  </data>
+  <data name="EditServerConnection_UseAsDefault" xml:space="preserve">
+    <value>Use as Default</value>
+  </data>
 </root>

--- a/src/Certify.UI.Shared/Windows/EditServerConnection.xaml
+++ b/src/Certify.UI.Shared/Windows/EditServerConnection.xaml
@@ -8,7 +8,7 @@
     xmlns:local="clr-namespace:Certify.UI.Windows"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
-    Title="Edit Server Connection"
+    Title="{x:Static res:SR.EditServerConnection_Title}"
     Width="540"
     Height="320"
     Background="{DynamicResource MahApps.Brushes.Window.Background}"
@@ -32,7 +32,8 @@
             VerticalAlignment="Top"
             DockPanel.Dock="Top"
             Style="{StaticResource Instructions}"
-            TextWrapping="Wrap"><Run Text="By default a service API will be bound to localhost:9696. Additional service configuration is required for remote connection (bound IP, enabling https, firewall rules etc)." /><LineBreak /><Run /></TextBlock>
+            Text="{x:Static res:SR.EditServerConnection_Instruction}"
+            TextWrapping="Wrap" />
         <StackPanel
             Margin="0,0,0,8"
             DockPanel.Dock="Top"
@@ -40,7 +41,7 @@
             <Label
                 Width="120"
                 Margin="0,0,8,0"
-                Content="Connection Name" />
+                Content="{x:Static res:SR.EditServerConnection_ConnectionName}" />
             <TextBox
                 Width="300"
                 Height="23"
@@ -58,7 +59,7 @@
             <Label
                 Width="120"
                 Margin="0,0,8,0"
-                Content="Hostname or IP" />
+                Content="{x:Static res:SR.EditServerConnection_HostnameOrIP}" />
             <TextBox
                 Width="300"
                 Height="23"
@@ -74,7 +75,7 @@
                 Width="120"
                 Margin="0,0,8,0"
                 VerticalAlignment="Top"
-                Content="Port" />
+                Content="{x:Static res:SR.EditServerConnection_Port}" />
             <TextBox
                 Width="300"
                 Height="23"
@@ -89,7 +90,7 @@
                 Width="120"
                 Margin="0,0,8,0"
                 VerticalAlignment="Top"
-                Content="Use Https" />
+                Content="{x:Static res:SR.EditServerConnection_UseHTTPS}" />
             <CheckBox IsChecked="{Binding Item.UseHTTPS}" />
         </StackPanel>
         <StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
@@ -97,7 +98,7 @@
                 Width="120"
                 Margin="0,0,8,0"
                 VerticalAlignment="Top"
-                Content="Allow Untrusted TLS" />
+                Content="{x:Static res:SR.EditServerConnection_AllowUntrustedTLS}" />
             <CheckBox IsChecked="{Binding Item.AllowUntrusted}" />
         </StackPanel>
 
@@ -106,7 +107,7 @@
                 Width="120"
                 Margin="0,0,8,0"
                 VerticalAlignment="Top"
-                Content="Use as Default" />
+                Content="{x:Static res:SR.EditServerConnection_UseAsDefault}" />
             <CheckBox IsChecked="{Binding Item.IsDefault}" />
         </StackPanel>
 


### PR DESCRIPTION
## Summary
- localize Edit Server Connection dialog text
- add resource keys with Brazilian Portuguese translations

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abb25f4eb8832ebc66335fa559811c