### PR TITLE
Localize Server Connections window

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -2171,6 +2171,60 @@ namespace Certify.Locales {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Add Connection.
+        /// </summary>
+        public static string ServerConnections_AddConnection {
+            get {
+                return ResourceManager.GetString("ServerConnections_AddConnection", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string ServerConnections_Cancel {
+            get {
+                return ResourceManager.GetString("ServerConnections_Cancel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Connect.
+        /// </summary>
+        public static string ServerConnections_Connect {
+            get {
+                return ResourceManager.GetString("ServerConnections_Connect", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You can manage multiple connections to different servers:.
+        /// </summary>
+        public static string ServerConnections_Instructions {
+            get {
+                return ResourceManager.GetString("ServerConnections_Instructions", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Manage Connections.
+        /// </summary>
+        public static string ServerConnections_ManageConnections {
+            get {
+                return ResourceManager.GetString("ServerConnections_ManageConnections", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Server Connections.
+        /// </summary>
+        public static string ServerConnections_Title {
+            get {
+                return ResourceManager.GetString("ServerConnections_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Status: .
         /// </summary>
         public static string StatusLabel {

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -765,4 +765,22 @@
   <data name="ClickToCopy" xml:space="preserve">
     <value>Clique para copiar para a área de transferência</value>
   </data>
+  <data name="ServerConnections_Title" xml:space="preserve">
+    <value>Conexões do Servidor</value>
+  </data>
+  <data name="ServerConnections_ManageConnections" xml:space="preserve">
+    <value>Gerenciar conexões</value>
+  </data>
+  <data name="ServerConnections_Instructions" xml:space="preserve">
+    <value>Você pode gerenciar múltiplas conexões para diferentes servidores:</value>
+  </data>
+  <data name="ServerConnections_AddConnection" xml:space="preserve">
+    <value>Adicionar conexão</value>
+  </data>
+  <data name="ServerConnections_Connect" xml:space="preserve">
+    <value>Conectar</value>
+  </data>
+  <data name="ServerConnections_Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
 </root>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -816,4 +816,22 @@ for the certification process to work.</value>
   <data name="ClickToCopy" xml:space="preserve">
     <value>Click to copy to clipboard</value>
   </data>
+  <data name="ServerConnections_Title" xml:space="preserve">
+    <value>Server Connections</value>
+  </data>
+  <data name="ServerConnections_ManageConnections" xml:space="preserve">
+    <value>Manage Connections</value>
+  </data>
+  <data name="ServerConnections_Instructions" xml:space="preserve">
+    <value>You can manage multiple connections to different servers:</value>
+  </data>
+  <data name="ServerConnections_AddConnection" xml:space="preserve">
+    <value>Add Connection</value>
+  </data>
+  <data name="ServerConnections_Connect" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="ServerConnections_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
 </root>

--- a/src/Certify.UI.Shared/Windows/ServerConnections.xaml
+++ b/src/Certify.UI.Shared/Windows/ServerConnections.xaml
@@ -7,7 +7,8 @@
     xmlns:fa="http://schemas.fontawesome.io/icons/"
     xmlns:local="clr-namespace:Certify.UI.Windows"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Title="Server Connections"
+    xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
+    Title="{x:Static res:SR.ServerConnections_Title}"
     Width="384"
     Height="500"
     Background="{DynamicResource MahApps.Brushes.Window.Background}"
@@ -21,14 +22,14 @@
         <TextBlock
             DockPanel.Dock="Top"
             Style="{StaticResource SubheadingWithMargin}"
-            Text="Manage Connections" />
+            Text="{x:Static res:SR.ServerConnections_ManageConnections}" />
         <TextBlock
             DockPanel.Dock="Top"
             Style="{StaticResource Instructions}"
-            Text="You can manage multiple connections to different servers:" />
+            Text="{x:Static res:SR.ServerConnections_Instructions}" />
 
         <DockPanel DockPanel.Dock="Top">
-            <Button Click="AddConnection_Click">Add Connection</Button>
+            <Button Click="AddConnection_Click">{x:Static res:SR.ServerConnections_AddConnection}</Button>
         </DockPanel>
         <ScrollViewer DockPanel.Dock="Top">
             <ItemsControl x:Name="ConnectionList" Margin="0,16,0,0">
@@ -43,7 +44,7 @@
                                 Click="Connect_Click"
                                 CommandParameter="{Binding}"
                                 DockPanel.Dock="Left"
-                                ToolTip="Connect">
+                                ToolTip="{x:Static res:SR.ServerConnections_Connect}">
                                 <StackPanel Orientation="Horizontal">
                                     <fa:ImageAwesome
                                         HorizontalAlignment="Center"
@@ -116,7 +117,7 @@
                 Width="80"
                 Click="Button_Click"
                 DockPanel.Dock="Right">
-                Cancel
+                {x:Static res:SR.ServerConnections_Cancel}
             </Button>
         </DockPanel>
     </DockPanel>


### PR DESCRIPTION
## Summary
- localize ServerConnections window using SR resources
- add English and pt-BR strings for server connection actions

## Testing
- `dotnet build src/Certify.Locales/Certify.Locales.csproj` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb25f31a8832eb4bb46264566efc4