### PR TITLE
Add plugin models import to DNS cleanup test

### DIFF
--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsCleanupTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsCleanupTests.cs
@@ -7,6 +7,7 @@ using Certify.Management;
 using Certify.Models;
 using Certify.Models.Config;
 using Certify.Models.Providers;
+using Certify.Models.Plugins;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Certify.Core.Tests.Unit


### PR DESCRIPTION
## Summary
- add `Certify.Models.Plugins` using to DNS cleanup tests

## Testing
- `dotnet build src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abc6307960832e9fd421778cfa6edd