### PR TITLE
Use List return type for DNS provider plugin

### DIFF
--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsCleanupTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsCleanupTests.cs
@@ -41,7 +41,7 @@ namespace Certify.Core.Tests.Unit
         class MockDnsProviderPlugin : IDnsProviderProviderPlugin
         {
             public IDnsProvider GetProvider(Type pluginType, string id) => id == MockProviderId ? new MockDnsProvider() : null;
-            public IEnumerable<ChallengeProviderDefinition> GetProviders(Type pluginType) => new List<ChallengeProviderDefinition>
+            public List<ChallengeProviderDefinition> GetProviders(Type pluginType) => new List<ChallengeProviderDefinition>
             {
                 new ChallengeProviderDefinition
                 {


### PR DESCRIPTION
## Summary
- change MockDnsProviderPlugin GetProviders to return List instead of IEnumerable

## Testing
- `dotnet test src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abc710c3cc832eb11c744c9b2bc6b5