### PR TITLE
Include hostname in PFX export filename

### DIFF
--- a/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
+++ b/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
@@ -1985,7 +1985,8 @@ namespace Certify.Providers.ACME.Anvil
                 throw;
             }
 
-            var pfxFile = certId + ".pfx";
+            var hostNameSanitized = string.Join("_", primaryIdentifierPath.Split(Path.GetInvalidFileNameChars(), StringSplitOptions.RemoveEmptyEntries));
+            var pfxFile = $"{hostNameSanitized}-{certId}.pfx";
             var pfxPath = Path.Combine(storePath, pfxFile);
             var failedBuildMsg = "Failed to build certificate as PFX. Check system date/time is correct and that the issuing CA is a trusted root CA on this machine (or in custom_ca_certs). :";
 


### PR DESCRIPTION
## Summary
- include sanitized hostname when naming exported PFX files

## Testing
- `dotnet build src/Certify.Providers/ACME/Anvil/Certify.Providers.ACME.Anvil.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `dotnet test src/Certify.Tests/Certify.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe29f86a4832e999214a27bc4b6a6