### PR TITLE
Use managed certificate filename in downloads

### DIFF
--- a/src/Certify.Server/Certify.Server.Hub.Api/Controllers/v1/CertificateController.cs
+++ b/src/Certify.Server/Certify.Server.Hub.Api/Controllers/v1/CertificateController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Text;
+using System.IO;
 using Certify.Client;
 using Certify.Models;
 using Certify.Models.Hub;
@@ -108,7 +109,8 @@ namespace Certify.Server.Hub.Api.Controllers
 
                 if (format == "pfx")
                 {
-                    return new FileContentResult(exportResult.Result, "application/x-pkcs12") { FileDownloadName = "certificate.pfx" };
+                    var fileName = Path.GetFileName(managedCert.CertificatePath) ?? "certificate.pfx";
+                    return new FileContentResult(exportResult.Result, "application/x-pkcs12") { FileDownloadName = fileName };
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- derive PFX download name from the managed certificate path instead of using a fixed filename

## Testing
- `dotnet test src/Certify.Server/Certify.Server.Hub.Api.Tests/Certify.Server.Api.Public.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68abe2c1c5b0832eadc96fd988e64514