### PR TITLE
chore: rename assemblies to AutoSSL

### DIFF
--- a/scripts/chocolatey/tools/chocolateybeforemodify.ps1
+++ b/scripts/chocolatey/tools/chocolateybeforemodify.ps1
@@ -8,7 +8,7 @@
 #  the currently installed version, not from the new upgraded package version.
 
 # Close the UI window if currently open
-Get-Process | Where-Object {$_.ProcessName -eq 'Certify.UI'} | Foreach-Object { $_.CloseMainWindow() | Out-Null } | stop-process –force
+Get-Process | Where-Object {$_.ProcessName -eq 'AutoSSL.UI'} | Foreach-Object { $_.CloseMainWindow() | Out-Null } | stop-process –force
 
-# Stop the Certify.Service background service
-Get-Service Certify.Service | Where {$_.status –eq 'Running'} |  Stop-Service
+# Stop the AutoSSL.Service background service
+Get-Service AutoSSL.Service | Where {$_.status –eq 'Running'} |  Stop-Service

--- a/src/Certify.CLI/Certify.CLI.csproj
+++ b/src/Certify.CLI/Certify.CLI.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>net462;net9.0;</TargetFrameworks>
         <Configurations>Debug;Release;</Configurations>
-        <AssemblyName>Certify</AssemblyName>
+        <AssemblyName>AutoSSL</AssemblyName>
         <OutputType>Exe</OutputType>
         <Platforms>AnyCPU</Platforms>
         <LangVersion>latest</LangVersion>
@@ -38,8 +38,8 @@
 
         <ProjectGuid>{DA0CCD9F-8CBD-4471-93E0-53BCFB6CA25E}</ProjectGuid>
         <OutputType>Exe</OutputType>
-        <RootNamespace>Certify.CLI</RootNamespace>
-        <AssemblyName>Certify</AssemblyName>
+        <RootNamespace>AutoSSL.CLI</RootNamespace>
+        <AssemblyName>AutoSSL</AssemblyName>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <StartupObject>Certify.CLI.Program</StartupObject>

--- a/src/Certify.Core/Management/CertifyManager/CertifyManager.ManagedCertificates.cs
+++ b/src/Certify.Core/Management/CertifyManager/CertifyManager.ManagedCertificates.cs
@@ -945,12 +945,12 @@ namespace Certify.Management
 
                 var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
-                var cliPath = System.IO.Path.Combine(AppContext.BaseDirectory, isWindows ? "Certify.exe" : "certify");
+                var cliPath = System.IO.Path.Combine(AppContext.BaseDirectory, isWindows ? "AutoSSL.exe" : "autossl");
 
                 if (!File.Exists(cliPath) && AppContext.BaseDirectory.IndexOf("service", StringComparison.InvariantCultureIgnoreCase) > -1)
                 {
                     // if running as a deployed service in a subdirectory, adjust the path to the executable
-                    cliPath = System.IO.Path.Combine(AppContext.BaseDirectory, "..", isWindows ? "certify.exe" : "certify");
+                    cliPath = System.IO.Path.Combine(AppContext.BaseDirectory, "..", isWindows ? "AutoSSL.exe" : "autossl");
                 }
 
                 if (!File.Exists(cliPath))

--- a/src/Certify.Service/Certify.Service.csproj
+++ b/src/Certify.Service/Certify.Service.csproj
@@ -2,7 +2,8 @@
     <PropertyGroup>
         <TargetFramework>net462</TargetFramework>
         <Configurations>Debug;Release;</Configurations>
-        <AssemblyName>Certify.Service</AssemblyName>
+        <AssemblyName>AutoSSL.Service</AssemblyName>
+        <RootNamespace>AutoSSL.Service</RootNamespace>
         <OutputType>Exe</OutputType>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <ApplicationIcon>icon.ico</ApplicationIcon>

--- a/src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1
@@ -67,10 +67,10 @@ if (($installedVersion -and $installedVersion.DisplayVersion -ne $updateVersionS
     if ($downloadHash.Hash -eq $updateInfo.message.sha256) {
     
         # Close the UI window if currently open
-        Get-Process | Where-Object { $_.ProcessName -eq 'Certify.UI' } | Foreach-Object { $_.CloseMainWindow() | Out-Null } | stop-process –force
+        Get-Process | Where-Object { $_.ProcessName -eq 'AutoSSL.UI' } | Foreach-Object { $_.CloseMainWindow() | Out-Null } | stop-process –force
 
-        # Stop the Certify.Service background service
-        Get-Service -Name "Certify.Service" | Where-Object { $_.status –eq 'Running' } |  Stop-Service
+        # Stop the AutoSSL.Service background service
+        Get-Service -Name "AutoSSL.Service" | Where-Object { $_.status –eq 'Running' } |  Stop-Service
 
         # Run installer
         Start-Process -Wait -FilePath $setupFile -ArgumentList "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/CertifyServiceTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/CertifyServiceTests.cs
@@ -36,12 +36,12 @@ namespace Certify.Core.Tests.Unit
             Command certifyService;
             if (args == "")
             {
-                certifyService = Command.Run(".\\Certify.Service.exe");
+                certifyService = Command.Run(".\\AutoSSL.Service.exe");
                 await Task.Delay(2000);
             }
             else
             {
-                certifyService = Command.Run(".\\Certify.Service.exe", args);
+                certifyService = Command.Run(".\\AutoSSL.Service.exe", args);
             }
 
             return certifyService;
@@ -58,7 +58,7 @@ namespace Certify.Core.Tests.Unit
             return cmdResult;
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe does not start with args from CLI")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe does not start with args from CLI")]
         public async Task TestProgramMainFailsWithArgsCli()
         {
             var certifyService = await StartCertifyService("args");
@@ -71,24 +71,24 @@ namespace Certify.Core.Tests.Unit
             Assert.AreEqual(cmdResult.ExitCode, 1067, "Unexpected exit code");
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe starts from CLI with no args")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe starts from CLI with no args")]
         public async Task TestProgramMainStartsCli()
         {
             var certifyService = await StartCertifyService();
 
             var cmdResult = await StopCertifyService(certifyService);
 
-            Assert.IsTrue(cmdResult.StandardOutput.Contains("[Success] Name Certify.Service"));
+            Assert.IsTrue(cmdResult.StandardOutput.Contains("[Success] Name AutoSSL.Service"));
             Assert.IsTrue(cmdResult.StandardOutput.Contains("[Success] DisplayName Certify Certificate Manager Service (Instance: Debug)"));
             Assert.IsTrue(cmdResult.StandardOutput.Contains("[Success] Description Certify Certificate Manager Service"));
             Assert.IsTrue(cmdResult.StandardOutput.Contains("[Success] InstanceName Debug"));
-            Assert.IsTrue(cmdResult.StandardOutput.Contains("[Success] ServiceName Certify.Service$Debug"));
-            Assert.IsTrue(cmdResult.StandardOutput.Contains("The Certify.Service$Debug service is now running, press Control+C to exit."));
+            Assert.IsTrue(cmdResult.StandardOutput.Contains("[Success] ServiceName AutoSSL.Service$Debug"));
+            Assert.IsTrue(cmdResult.StandardOutput.Contains("The AutoSSL.Service$Debug service is now running, press Control+C to exit."));
             Assert.IsTrue(cmdResult.StandardOutput.Contains("Control+C detected, attempting to stop service."));
-            Assert.IsTrue(cmdResult.StandardOutput.Contains("The Certify.Service$Debug service has stopped."));
+            Assert.IsTrue(cmdResult.StandardOutput.Contains("The AutoSSL.Service$Debug service has stopped."));
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route GET /api/system/appversion")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route GET /api/system/appversion")]
         public async Task TestCertifyServiceAppVersionRoute()
         {
             var certifyService = await StartCertifyService();
@@ -108,7 +108,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid respose on route GET /api/system/updatecheck")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid respose on route GET /api/system/updatecheck")]
         public async Task TestCertifyServiceUpdateCheckRoute()
         {
             var certifyService = await StartCertifyService();
@@ -130,7 +130,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route GET /api/system/diagnostics")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route GET /api/system/diagnostics")]
         public async Task TestCertifyServiceDiagnosticsRoute()
         {
             var certifyService = await StartCertifyService();
@@ -170,7 +170,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route GET /api/system/datastores/providers")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route GET /api/system/datastores/providers")]
         public async Task TestCertifyServiceDatastoreProvidersRoute()
         {
             var certifyService = await StartCertifyService();
@@ -189,7 +189,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route GET /api/system/datastores/")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route GET /api/system/datastores/")]
         public async Task TestCertifyServiceDatastoresRoute()
         {
             var certifyService = await StartCertifyService();
@@ -209,7 +209,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route POST /api/system/datastores/test")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route POST /api/system/datastores/test")]
         public async Task TestCertifyServiceDatastoresTestRoute()
         {
             var certifyService = await StartCertifyService();
@@ -236,7 +236,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route POST /api/system/datastores/update")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route POST /api/system/datastores/update")]
         public async Task TestCertifyServiceDatastoresUpdateRoute()
         {
             var certifyService = await StartCertifyService();
@@ -263,7 +263,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route POST /api/system/datastores/setdefault/{dataStoreId}")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route POST /api/system/datastores/setdefault/{dataStoreId}")]
         public async Task TestCertifyServiceDatastoresSetDefaultRoute()
         {
             var certifyService = await StartCertifyService();
@@ -290,7 +290,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route POST /api/system/datastores/delete")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route POST /api/system/datastores/delete")]
         [Ignore]
         public async Task TestCertifyServiceDatastoresDeleteRoute()
         {
@@ -325,7 +325,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route POST /api/system/datastores/copy/{sourceId}/{destId}")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route POST /api/system/datastores/copy/{sourceId}/{destId}")]
         [Ignore]
         public async Task TestCertifyServiceDatastoresCopyRoute()
         {
@@ -368,7 +368,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route GET /api/server/isavailable/{serverType}")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route GET /api/server/isavailable/{serverType}")]
         public async Task TestCertifyServiceServerIsavailableRoute()
         {
             var certifyService = await StartCertifyService();
@@ -388,7 +388,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route GET /api/server/sitelist/{serverType}")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route GET /api/server/sitelist/{serverType}")]
         public async Task TestCertifyServiceServerSitelistRoute()
         {
             var certifyService = await StartCertifyService();
@@ -407,7 +407,7 @@ namespace Certify.Core.Tests.Unit
             }
         }
 
-        [TestMethod, Description("Validate that Certify.Service.exe returns a valid response on route GET /api/server/version/{serverType}")]
+        [TestMethod, Description("Validate that AutoSSL.Service.exe returns a valid response on route GET /api/server/version/{serverType}")]
         public async Task TestCertifyServiceServerVersionRoute()
         {
             var certifyService = await StartCertifyService();

--- a/src/Certify.UI/Certify.UI.csproj
+++ b/src/Certify.UI/Certify.UI.csproj
@@ -6,8 +6,8 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C4957629-D567-4934-A193-37B325E7398F}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <RootNamespace>Certify.UI</RootNamespace>
-    <AssemblyName>Certify.UI</AssemblyName>
+    <RootNamespace>AutoSSL.UI</RootNamespace>
+    <AssemblyName>AutoSSL.UI</AssemblyName>
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
## Summary
- rename assemblies to use the AutoSSL prefix
- update scripts and tests for new AutoSSL executable names

## Testing
- `dotnet build src/Certify.Core.Service.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository ... not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68acb9c43f64832e9fe0c65796ecf3ab