### PR TITLE
chore: rebrand app data and friendly names

### DIFF
--- a/src/Certify.Client/CertifyApiClient.cs
+++ b/src/Certify.Client/CertifyApiClient.cs
@@ -159,7 +159,7 @@ namespace Certify.Client
                 }
             }
 
-            _client.DefaultRequestHeaders.Add("User-Agent", "Certify/App");
+            _client.DefaultRequestHeaders.Add("User-Agent", "AutoSSL/App");
             _client.Timeout = new TimeSpan(0, 20, 0); // 20 min timeout on service api calls
         }
 

--- a/src/Certify.Core/Management/CertifyManager/CertifyManager.ManagedCertificates.cs
+++ b/src/Certify.Core/Management/CertifyManager/CertifyManager.ManagedCertificates.cs
@@ -991,7 +991,7 @@ namespace Certify.Management
                 if (_httpChallengeServerClient == null)
                 {
                     _httpChallengeServerClient = new System.Net.Http.HttpClient();
-                    _httpChallengeServerClient.DefaultRequestHeaders.Add("User-Agent", Util.GetUserAgent() + " CertifyManager");
+                    _httpChallengeServerClient.DefaultRequestHeaders.Add("User-Agent", Util.GetUserAgent() + " AutoSSLManager");
                 }
 
                 var started = await IsHttpChallengeProcessStarted(true);

--- a/src/Certify.Models/Config/Preferences.cs
+++ b/src/Certify.Models/Config/Preferences.cs
@@ -7,15 +7,15 @@ namespace Certify.Models
     {
         None = 0,
         /// <summary>
-        /// Clean up [Certify] expired certificates
+        /// Clean up [AutoSSL] expired certificates
         /// </summary>
         AfterExpiry = 1,
         /// <summary>
-        /// Clean up [Certify] renewed certificates
+        /// Clean up [AutoSSL] renewed certificates
         /// </summary>
         AfterRenewal = 2,
         /// <summary>
-        /// Clean up all [Certify] certificates not currently managed
+        /// Clean up all [AutoSSL] certificates not currently managed
         /// </summary>
         FullCleanup = 3
     }

--- a/src/Certify.Models/Providers/Internal/LicenseManager.cs
+++ b/src/Certify.Models/Providers/Internal/LicenseManager.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using Certify.Models;
 using Certify.Models.Plugins;
 using Certify.Models.Shared;
 using Newtonsoft.Json;
@@ -286,7 +287,8 @@ namespace Certify.Providers.Internal
         {
             if (_enableLog)
             {
-                var logFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "certify", "logs", "licensing.log");
+                var logPath = EnvironmentUtil.EnsuredAppDataPath("logs");
+                var logFile = Path.Combine(logPath, "licensing.log");
                 if (!File.Exists(logFile))
                 {
                     File.CreateText(logFile).Close();

--- a/src/Certify.Models/Shared/SharedConstants.cs
+++ b/src/Certify.Models/Shared/SharedConstants.cs
@@ -3,9 +3,11 @@
     public static class SharedConstants
     {
 #if _DEMO_
-        public const string APPDATASUBFOLDER = "CertifyDemo";
+        public const string APPDATASUBFOLDER = "AutoSSLDemo";
 #else
-        public const string APPDATASUBFOLDER = "certify";
+        public const string APPDATASUBFOLDER = "autossl";
 #endif
+
+        public const string LEGACY_APPDATASUBFOLDER = "certify";
     }
 }

--- a/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
+++ b/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
@@ -1502,7 +1502,7 @@ namespace Certify.Providers.ACME.Anvil
                 csrKey = KeyFactory.NewKey(keyAlg, rsaKeySize);
             }
 
-            var certFriendlyName = $"{config.PrimaryDomain} [Certify] ";
+            var certFriendlyName = $"{config.PrimaryDomain} [AutoSSL] ";
 
             // generate cert
             CertificateChain certificateChain = null;

--- a/src/Certify.Providers/DNS/AcmeDns/AcmeDns/DnsProviderAcmeDns.cs
+++ b/src/Certify.Providers/DNS/AcmeDns/AcmeDns/DnsProviderAcmeDns.cs
@@ -93,7 +93,7 @@ namespace Certify.Providers.DNS.AcmeDns
             _settingsPath = EnvironmentUtil.EnsuredAppDataPath();
 
             _client = new HttpClient();
-            _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderAcmeDns");
+            _client.DefaultRequestHeaders.Add("User-Agent", "AutoSSL/DnsProviderAcmeDns");
 
             _serializerSettings = new JsonSerializerSettings
             {

--- a/src/Certify.Providers/DNS/CertifyDns/DnsProviderCertifyDns.cs
+++ b/src/Certify.Providers/DNS/CertifyDns/DnsProviderCertifyDns.cs
@@ -74,7 +74,7 @@ namespace Certify.Providers.DNS.CertifyDns
             _settingsPath = EnvironmentUtil.EnsuredAppDataPath();
 
             _client = new HttpClient();
-            _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderCertifyDns");
+            _client.DefaultRequestHeaders.Add("User-Agent", "AutoSSL/DnsProviderCertifyDns");
 
             _serializerSettings = new JsonSerializerSettings
             {

--- a/src/Certify.Providers/DNS/CertifyManaged/DnsProviderCertifyManaged.cs
+++ b/src/Certify.Providers/DNS/CertifyManaged/DnsProviderCertifyManaged.cs
@@ -63,7 +63,7 @@ namespace Certify.Providers.DNS.CertifyManaged
             _client = new HttpClient();
 
 #endif
-            _client.DefaultRequestHeaders.Add("User-Agent", "Certify/DnsProviderCertifyManaged");
+            _client.DefaultRequestHeaders.Add("User-Agent", "AutoSSL/DnsProviderCertifyManaged");
 
             _serializerSettings = new JsonSerializerSettings
             {

--- a/src/Certify.Providers/DNS/IONOS/DnsProviderIONOS.cs
+++ b/src/Certify.Providers/DNS/IONOS/DnsProviderIONOS.cs
@@ -223,7 +223,7 @@ namespace Certify.Providers.DNS.IONOS
 
             request.Headers.Add("accept", "application/json");
             request.Headers.Add("X-API-Key", $"{_credentials["public"]}.{_credentials["secret"]}");
-            request.Headers.Add("User-Agent", "Certify");
+            request.Headers.Add("User-Agent", "AutoSSL");
             return request;
         }
 

--- a/src/Certify.Server/Certify.Server.Core/Certify.Server.Core/Controllers/ControllerBase.cs
+++ b/src/Certify.Server/Certify.Server.Core/Certify.Server.Core/Controllers/ControllerBase.cs
@@ -65,7 +65,7 @@ namespace Certify.Service.Controllers
     }
 
     [ApiController]
-    [Authorize(Policy = "CertifyServiceAuth")]
+    [Authorize(Policy = "AutoSSLServiceAuth")]
     public class ControllerBase : Controller
     {
         internal void DebugLog(string msg = null,

--- a/src/Certify.Server/Certify.Server.Core/Certify.Server.Core/Startup.cs
+++ b/src/Certify.Server/Certify.Server.Core/Certify.Server.Core/Startup.cs
@@ -14,8 +14,8 @@ namespace Certify.Server.Core
     public class Startup
     {
         private const string ServiceAuthScheme = "ServiceAuthScheme";
-        private const string CertifyServiceAuthPolicy = "CertifyServiceAuth";
-        private const string SwaggerDocTitle = "Certify Agent Service Internal API";
+        private const string AutoSSLServiceAuthPolicy = "AutoSSLServiceAuth";
+        private const string SwaggerDocTitle = "AutoSSL Agent Service Internal API";
         private const string SwaggerDocVersion = "v1";
         private const string SwaggerDocDescription = "Provides a private API for use by the autoSSL Desktop UI and related components. This internal API changes between versions, you should use the public Hub API when building integrations instead.";
 
@@ -102,7 +102,7 @@ namespace Certify.Server.Core
         private void ConfigureDataProtection(IServiceCollection services)
         {
             var appDataPath = EnvironmentUtil.EnsuredAppDataPath("keys");
-            services.AddDataProtection(a => a.ApplicationDiscriminator = "certify")
+            services.AddDataProtection(a => a.ApplicationDiscriminator = SharedConstants.APPDATASUBFOLDER)
                     .PersistKeysToFileSystem(new DirectoryInfo(appDataPath));
         }
 
@@ -138,7 +138,7 @@ namespace Certify.Server.Core
 
             services.AddAuthorization(options =>
             {
-                options.AddPolicy(CertifyServiceAuthPolicy, policy =>
+                options.AddPolicy(AutoSSLServiceAuthPolicy, policy =>
                 {
                     if (windowsAuthRequired)
                     {

--- a/src/Certify.Server/Certify.Server.HubService/Program.cs
+++ b/src/Certify.Server/Certify.Server.HubService/Program.cs
@@ -134,7 +134,7 @@ var appDataPath = EnvironmentUtil.EnsuredAppDataPath("keys");
 builder.Services
     .AddDataProtection(a =>
     {
-        a.ApplicationDiscriminator = "certify";
+        a.ApplicationDiscriminator = SharedConstants.APPDATASUBFOLDER;
     })
     .PersistKeysToFileSystem(new DirectoryInfo(appDataPath));
 
@@ -149,9 +149,9 @@ builder.Services.AddSwaggerGen(c =>
 
     c.SwaggerDoc("v1", new OpenApiInfo
     {
-        Title = "Certify Management Hub API",
+        Title = "AutoSSL Management Hub API",
         Version = "v1",
-        Description = "The Certify Management Hub API provides a certificate services API for use in UI, devops, CI/CD, middleware etc. See certifytheweb.com for more details."
+        Description = "The AutoSSL Management Hub API provides a certificate services API for use in UI, devops, CI/CD, middleware etc."
     });
 
     c.UseAllOfToExtendReferenceSchemas();
@@ -327,7 +327,7 @@ app.UseSwagger();
 app.MapScalarApiReference("/api/docs/", options =>
 {
     options
-                    .WithTitle("Certify Management Hub API")
+                    .WithTitle("AutoSSL Management Hub API")
                     .WithTheme(ScalarTheme.Solarized)
                     .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
                     .WithOpenApiRoutePattern("/swagger/v1/swagger.json");

--- a/src/Certify.Service/OwinService.cs
+++ b/src/Certify.Service/OwinService.cs
@@ -159,7 +159,7 @@ namespace Certify.Service
             if (currentCert == null)
             {
                 // create and install new cert
-                var newCert = CertificateManager.GenerateSelfSignedCertificate(certSubject, DateTime.UtcNow, DateTime.UtcNow.AddYears(3), "[Certify Background API]");
+                var newCert = CertificateManager.GenerateSelfSignedCertificate(certSubject, DateTime.UtcNow, DateTime.UtcNow.AddYears(3), "[AutoSSL Background API]");
                 currentCert = CertificateManager.StoreCertificate(newCert, storeName: certStore);
 
                 certUpdated = true;

--- a/src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/AutoUpdate/AutoUpdate.ps1
@@ -1,12 +1,12 @@
 ﻿param ([int]$Days=7, [switch]$Force)
 
-# Certify The Web - App Updater Script
+# AutoSSL - App Updater Script
 # Schedule this powershell script task using an Administrator account for automatic update N days after the last official release
 
 $installAfterNDays = $Days
 $forceInstall = $Force
-$scriptName = "[Certify The Web - App Update Script]"
-$eventLogAppName = "Certify The Web - Auto Update"
+$scriptName = "[AutoSSL - App Update Script]"
+$eventLogAppName = "AutoSSL - Auto Update"
 
 New-EventLog –LogName "Application" –Source $eventLogAppName -ErrorAction SilentlyContinue
 
@@ -14,7 +14,7 @@ New-EventLog –LogName "Application" –Source $eventLogAppName -ErrorAction Si
 
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
 
-$installedVersion = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -match "^(Certify The Web|Certify Certificate Manager).*" }
+$installedVersion = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.DisplayName -match "^(AutoSSL|AutoSSL Certificate Manager).*" }
 $installedVersionString = $installedVersion.DisplayVersion
 
 $apiUrl = "https://update.autoip.com.br/v1/update?context=autoupdate&version=" + $installedVersionString

--- a/src/Certify.Shared/Management/CertificateManager.cs
+++ b/src/Certify.Shared/Management/CertificateManager.cs
@@ -31,11 +31,13 @@ namespace Certify.Management
         public const string DEFAULT_STORE_NAME = "My";
         public const string WEBHOSTING_STORE_NAME = "WebHosting";
         public const string DISALLOWED_STORE_NAME = "Disallowed";
+        public const string FRIENDLY_NAME_SUFFIX = "[AutoSSL]";
+        public const string LEGACY_FRIENDLY_NAME_SUFFIX = "[Certify]";
         private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         private static readonly bool IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         private static readonly bool IsMac = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
-        public static X509Certificate2 GenerateSelfSignedCertificate(string domain, DateTimeOffset? dateFrom = null, DateTimeOffset? dateTo = null, string suffix = "[Certify]", string subject = null, string keyType = StandardKeyTypes.RSA256)
+        public static X509Certificate2 GenerateSelfSignedCertificate(string domain, DateTimeOffset? dateFrom = null, DateTimeOffset? dateTo = null, string suffix = FRIENDLY_NAME_SUFFIX, string subject = null, string keyType = StandardKeyTypes.RSA256)
         {
 
             // configure generators
@@ -408,7 +410,7 @@ namespace Certify.Management
                 {
                     certificate.GetExpirationDateString();
 
-                    certificate.FriendlyName = $"{host} [Certify] - {certificate.GetEffectiveDateString()} to {certificate.GetExpirationDateString()}";
+                    certificate.FriendlyName = $"{host} {FRIENDLY_NAME_SUFFIX} - {certificate.GetEffectiveDateString()} to {certificate.GetExpirationDateString()}";
 
                 }
             }
@@ -847,7 +849,7 @@ namespace Certify.Management
         }
 
         /// <summary>
-        /// Remove all certificate expired a month or more before the given date, with [Certify] in
+        /// Remove all certificate expired a month or more before the given date, with [AutoSSL] in
         /// the friendly name, optionally where there are no existing bindings, vary by Cleanup Mode
         /// </summary>
         /// <param name="expiryBefore">  </param>
@@ -894,10 +896,10 @@ namespace Certify.Management
                         {
                             if (cleanupMode == Models.CertificateCleanupMode.AfterExpiry)
                             {
-                                // queue removal of existing expired cert with [Certify] text in friendly name.
+                                // queue removal of existing expired cert with [AutoSSL] text in friendly name.
                                 if (
                                      (string.IsNullOrWhiteSpace(matchingName) || (c.FriendlyName.StartsWith(matchingName)))
-                                     && c.FriendlyName.Contains("[Certify]")
+                                     && (c.FriendlyName.Contains(FRIENDLY_NAME_SUFFIX) || c.FriendlyName.Contains(LEGACY_FRIENDLY_NAME_SUFFIX))
                                      && c.NotAfter < expiryBefore
                                      )
                                 {
@@ -910,7 +912,7 @@ namespace Certify.Management
 
                                 if (
                                     (!string.IsNullOrWhiteSpace(matchingName) && c.FriendlyName.StartsWith(matchingName))
-                                    && c.FriendlyName.Contains("[Certify]")
+                                    && (c.FriendlyName.Contains(FRIENDLY_NAME_SUFFIX) || c.FriendlyName.Contains(LEGACY_FRIENDLY_NAME_SUFFIX))
                                     )
                                 {
                                     certsToRemove.Add(c);
@@ -922,7 +924,7 @@ namespace Certify.Management
 
                                 if (
                                      (string.IsNullOrWhiteSpace(matchingName) || (c.FriendlyName.StartsWith(matchingName)))
-                                    && c.FriendlyName.Contains("[Certify]")
+                                    && (c.FriendlyName.Contains(FRIENDLY_NAME_SUFFIX) || c.FriendlyName.Contains(LEGACY_FRIENDLY_NAME_SUFFIX))
                                     )
                                 {
                                     certsToRemove.Add(c);

--- a/src/Certify.Shared/Utils/DemoDataGenerator.cs
+++ b/src/Certify.Shared/Utils/DemoDataGenerator.cs
@@ -51,7 +51,7 @@ namespace Certify.Shared.Core.Utils
                         item.DateStart = certStart;
                         item.DateLastRenewalAttempt = certStart;
                         item.DateExpiry = certStart.AddDays(certLifetime);
-                        item.CertificateFriendlyName = $"{item.GetCertificateIdentifiers().First().Value} [CertifyDemo] - {item.DateStart} to {item.DateExpiry}";
+                        item.CertificateFriendlyName = $"{item.GetCertificateIdentifiers().First().Value} [AutoSSLDemo] - {item.DateStart} to {item.DateExpiry}";
                         item.Comments = "[DemoData-2] This is an example item showing failure.";
                         item.LastAttemptedCA = item.CertificateCurrentCA;
                         item.LastRenewalStatus = RequestState.Error;
@@ -66,7 +66,7 @@ namespace Certify.Shared.Core.Utils
                         item.DateStart = certStart;
                         item.DateLastRenewalAttempt = certStart;
                         item.DateExpiry = certStart.AddDays(certLifetime);
-                        item.CertificateFriendlyName = $"{item.GetCertificateIdentifiers().First().Value} [CertifyDemo] - {item.DateStart} to {item.DateExpiry}";
+                        item.CertificateFriendlyName = $"{item.GetCertificateIdentifiers().First().Value} [AutoSSLDemo] - {item.DateStart} to {item.DateExpiry}";
                         item.Comments = "[DemoData-3] This is an example item showing success";
                         item.LastAttemptedCA = item.CertificateCurrentCA;
                         item.LastRenewalStatus = RequestState.Success;

--- a/src/Certify.Shared/Utils/EnvironmentUtil.cs
+++ b/src/Certify.Shared/Utils/EnvironmentUtil.cs
@@ -117,6 +117,18 @@ namespace Certify.Models
 
             var path = Path.Combine(parts.ToArray());
 
+            var legacyParts = new List<string>(parts);
+            var index = legacyParts.IndexOf(Models.SharedConstants.APPDATASUBFOLDER);
+            if (index >= 0)
+            {
+                legacyParts[index] = Models.SharedConstants.LEGACY_APPDATASUBFOLDER;
+                var legacyPath = Path.Combine(legacyParts.ToArray());
+                if (!Directory.Exists(path) && Directory.Exists(legacyPath))
+                {
+                    Directory.Move(legacyPath, path);
+                }
+            }
+
             if (!skipCreation)
             {
                 CreateAndApplyRestrictedACL(path);

--- a/src/Certify.Shared/Utils/HttpChallengeServer.cs
+++ b/src/Certify.Shared/Utils/HttpChallengeServer.cs
@@ -128,7 +128,7 @@ namespace Certify.Core.Management.Challenges
                     _baseUri = $"http://{serverConfig.Host}:{serverConfig.Port}/api/";
 
                     _apiClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true });
-                    _apiClient.DefaultRequestHeaders.Add("User-Agent", "Certify/HttpChallengeServer");
+                    _apiClient.DefaultRequestHeaders.Add("User-Agent", "AutoSSL/HttpChallengeServer");
                     _apiClient.Timeout = new TimeSpan(0, 0, 20);
 
                     var uriPrefix = $"http://+:{serverConfig.HttpChallengeServerPort}{_challengePrefix}";

--- a/src/Certify.Shared/Utils/NetworkUtils.cs
+++ b/src/Certify.Shared/Utils/NetworkUtils.cs
@@ -11,6 +11,7 @@ using Certify.Models.API;
 using ARSoft.Tools.Net;
 using ARSoft.Tools.Net.Dns;
 #endif
+using Certify.Management;
 using Certify.Models.Config;
 using Certify.Models.Providers;
 
@@ -32,7 +33,7 @@ namespace Certify.Shared.Core.Utils
 
             _httpClient = new HttpClient(_httpClientHandler);
             _httpClient.Timeout = new TimeSpan(0, 0, 5);
-            _httpClient.DefaultRequestHeaders.Add("User-Agent", Certify.Management.Util.GetUserAgent());
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", Util.GetUserAgent());
 
         }
 

--- a/src/Certify.Shared/Utils/Util.cs
+++ b/src/Certify.Shared/Utils/Util.cs
@@ -178,7 +178,7 @@ namespace Certify.Management
 
         public static string GetUserAgent()
         {
-            var versionName = "Certify/" + GetAppVersion().ToString();
+            var versionName = "AutoSSL/" + GetAppVersion().ToString();
             return $"{versionName} ({RuntimeInformation.OSDescription}; {Environment.OSVersion}) ";
         }
 
@@ -309,10 +309,18 @@ namespace Certify.Management
 
         public static string GetUserLocalAppDataFolder()
         {
-            var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Models.SharedConstants.APPDATASUBFOLDER);
-            if (!System.IO.Directory.Exists(path))
+            var basePath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var path = Path.Combine(basePath, Models.SharedConstants.APPDATASUBFOLDER);
+            var legacyPath = Path.Combine(basePath, Models.SharedConstants.LEGACY_APPDATASUBFOLDER);
+
+            if (!Directory.Exists(path) && Directory.Exists(legacyPath))
             {
-                System.IO.Directory.CreateDirectory(path);
+                Directory.Move(legacyPath, path);
+            }
+
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
             }
 
             return path;

--- a/src/Certify.Tests/Certify.Core.Tests.Integration/CertificateStoreCleanup.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/CertificateStoreCleanup.cs
@@ -45,7 +45,7 @@ namespace Certify.Core.Tests
                 );
 
             // run cleanup process, removes certs which have expired for over a month and have
-            // [Certify] in the friendly name
+            // [AutoSSL] in the friendly name
             CertificateManager.PerformCertificateStoreCleanup(Models.CertificateCleanupMode.AfterExpiry, new DateTime(1936, 06, 01), null, null);
 
             // check the correct certificates have been removed

--- a/src/Certify.Tests/Certify.Core.Tests.Integration/CertifyManagerTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/CertifyManagerTests.cs
@@ -177,7 +177,7 @@ namespace Certify.Core.Tests
             // Validate return from CertifyManager.PerformExport()
             Assert.IsNotNull(performExportRes, "Expected response from CertifyManager.PerformExport() to not be null");
             Assert.AreEqual(1, performExportRes.FormatVersion, "Expected FormatVersion of response from CertifyManager.PerformExport() to equal 1 by default");
-            Assert.AreEqual("Certify The Web - Exported App Settings", performExportRes.Description, "Unexpected default Description in response from CertifyManager.PerformExport()");
+            Assert.AreEqual("AutoIP - AUTOSSL Exported App Settings", performExportRes.Description, "Unexpected default Description in response from CertifyManager.PerformExport()");
             Assert.AreEqual(0, performExportRes.Errors.Count, "Unexpected Errors in response from CertifyManager.PerformExport()");
             Assert.AreEqual(Certify.Management.Util.GetAppVersion(), performExportRes.SystemVersion?.ToVersion(), "Unexpected SystemVersion in response from CertifyManager.PerformExport()");
             Assert.AreEqual(Environment.MachineName, performExportRes.SourceName, "Unexpected SourceName in response from CertifyManager.PerformExport()");

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/CertificateOperationTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/CertificateOperationTests.cs
@@ -15,7 +15,7 @@ namespace Certify.Core.Tests.Unit
         public void TestSelfSignedCertCreate()
         {
 
-            var cert = CertificateManager.GenerateSelfSignedCertificate("test.com", new DateTime(1934, 01, 01), new DateTime(1934, 03, 01), suffix: "[Certify](test)");
+            var cert = CertificateManager.GenerateSelfSignedCertificate("test.com", new DateTime(1934, 01, 01), new DateTime(1934, 03, 01), suffix: "[AutoSSL](test)");
             Assert.IsNotNull(cert);
         }
 
@@ -23,7 +23,7 @@ namespace Certify.Core.Tests.Unit
         public void TestSelfSignedCertCreateAndStore()
         {
 
-            var cert = CertificateManager.GenerateSelfSignedCertificate("test.com", new DateTime(1934, 01, 01), new DateTime(1934, 03, 01), suffix: "[Certify](test)");
+            var cert = CertificateManager.GenerateSelfSignedCertificate("test.com", new DateTime(1934, 01, 01), new DateTime(1934, 03, 01), suffix: "[AutoSSL](test)");
             Assert.IsNotNull(cert);
 
             CertificateManager.StoreCertificate(cert, CertificateManager.DEFAULT_STORE_NAME);
@@ -38,7 +38,7 @@ namespace Certify.Core.Tests.Unit
         public void TestSelfSignedLocalhostCertCreateAndStore()
         {
 
-            var cert = CertificateManager.GenerateSelfSignedCertificate("localhost", DateTime.UtcNow, DateTime.UtcNow.AddDays(30), suffix: "[Certify](test)");
+            var cert = CertificateManager.GenerateSelfSignedCertificate("localhost", DateTime.UtcNow, DateTime.UtcNow.AddDays(30), suffix: "[AutoSSL](test)");
             Assert.IsNotNull(cert);
 
             CertificateManager.StoreCertificate(cert, CertificateManager.DEFAULT_STORE_NAME);
@@ -58,7 +58,7 @@ namespace Certify.Core.Tests.Unit
                 return;
             }
 
-            var cert = CertificateManager.GenerateSelfSignedCertificate("localhost", DateTime.UtcNow, DateTime.UtcNow.AddDays(30), suffix: "[Certify](test)", keyType: StandardKeyTypes.RSA256);
+            var cert = CertificateManager.GenerateSelfSignedCertificate("localhost", DateTime.UtcNow, DateTime.UtcNow.AddDays(30), suffix: "[AutoSSL](test)", keyType: StandardKeyTypes.RSA256);
 
             CertificateManager.StoreCertificate(cert, CertificateManager.DEFAULT_STORE_NAME);
 
@@ -85,7 +85,7 @@ namespace Certify.Core.Tests.Unit
                 return;
             }
 
-            var cert = CertificateManager.GenerateSelfSignedCertificate("localhost", DateTime.UtcNow, DateTime.UtcNow.AddDays(30), suffix: "[Certify](test)", keyType: StandardKeyTypes.ECDSA256);
+            var cert = CertificateManager.GenerateSelfSignedCertificate("localhost", DateTime.UtcNow, DateTime.UtcNow.AddDays(30), suffix: "[AutoSSL](test)", keyType: StandardKeyTypes.ECDSA256);
 
             CertificateManager.StoreCertificate(cert, CertificateManager.DEFAULT_STORE_NAME);
 
@@ -120,7 +120,7 @@ namespace Certify.Core.Tests.Unit
 
             var log = new Loggy(LoggerFactory.Create(builder => builder.AddDebug()).CreateLogger<CertificateOperationTests>());
 
-            var cert = CertificateManager.GenerateSelfSignedCertificate("localhost", DateTime.UtcNow, DateTime.UtcNow.AddDays(30), suffix: "[Certify](test)", keyType: keyType);
+            var cert = CertificateManager.GenerateSelfSignedCertificate("localhost", DateTime.UtcNow, DateTime.UtcNow.AddDays(30), suffix: "[AutoSSL](test)", keyType: keyType);
 
             CertificateManager.StoreCertificate(cert, CertificateManager.DEFAULT_STORE_NAME);
 

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/CertifyServiceTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/CertifyServiceTests.cs
@@ -27,7 +27,7 @@ namespace Certify.Core.Tests.Unit
             serviceUri = $"{(serviceConfig.UseHTTPS ? "https" : "http")}://{serviceConfig.Host}:{serviceConfig.Port}";
             var httpHandler = new HttpClientHandler { UseDefaultCredentials = true };
             _httpClient = new HttpClient(httpHandler);
-            _httpClient.DefaultRequestHeaders.Add("User-Agent", "Certify/App");
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "AutoSSL/App");
             _httpClient.BaseAddress = new Uri(serviceUri + "/api/");
         }
 


### PR DESCRIPTION
## Summary
- rename app data folder to `autossl` and migrate old `certify` data
- rebrand default certificate friendly names to `[AutoSSL]`
- replace remaining `Certify` strings in user agents, logs, and APIs

## Testing
- `dotnet test src/Certify.Core.Service.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68acbc241cd8832e92401093e0b02a5d