### PR TITLE
Update documentation links and domain references

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,5 +11,5 @@ Only the latest version is supported for updates. Users must update to stay curr
 
 ## Reporting a Vulnerability
 
-Vulnerabilities or security issues can be reported to `support at certifytheweb.com` - we do not currently operate a bug bounty program.
-During normal use the app requires elevated permissions, this has associated risks which are documented here: https://docs.certifytheweb.com/docs/guides/security
+Vulnerabilities or security issues can be reported to `support at autossl.com` - we do not currently operate a bug bounty program.
+During normal use the app requires elevated permissions, this has associated risks which are documented here: https://docs.autossl.com/guides/security

--- a/src/Certify.CLI/CertifyCLI.cs
+++ b/src/Certify.CLI/CertifyCLI.cs
@@ -112,7 +112,7 @@ namespace Certify.CLI
             System.Console.WriteLine("certify backup export <directory or full filename> <encryption secret> : export a backup file (auto-named if a directory) using the given secret password for encryption.");
             System.Console.WriteLine("certify backup import preview <full filename> <encryption secret> : import a backup file using the given secret password for encryption. 'preview' is optional and is used to test a backup without importing anything.");
             System.Console.WriteLine("\n\n");
-            System.Console.WriteLine("For help, see the docs at https://docs.certifytheweb.com");
+            System.Console.WriteLine("For help, see the docs at https://docs.autossl.com");
         }
     }
 }

--- a/src/Certify.Core/Management/Challenges/DNS/DnsProviderManual.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsProviderManual.cs
@@ -28,7 +28,7 @@ namespace Certify.Core.Management.Challenges.DNS
             Id = "DNS01.Manual",
             Title = "(Update DNS Manually)",
             Description = "When a DNS update is required, wait for manual changes.",
-            HelpUrl = "https://docs.certifytheweb.com/docs/dns/validation",
+            HelpUrl = "https://docs.autossl.com/dns/validation",
             PropagationDelaySeconds = -1,
             ProviderParameters = new List<ProviderParameter>() { new ProviderParameter { Description = "Email address to prompt changes", IsRequired = false, Key = "email", Name = "Email to Notify (optional)", IsCredential = false } },
             ChallengeType = Models.SupportedChallengeTypes.CHALLENGE_TYPE_DNS,

--- a/src/Certify.Core/Management/Challenges/DNS/DnsProviderScripting.cs
+++ b/src/Certify.Core/Management/Challenges/DNS/DnsProviderScripting.cs
@@ -35,7 +35,7 @@ namespace Certify.Core.Management.Challenges.DNS
             Id = "DNS01.Scripting",
             Title = "(Use Custom Script)",
             Description = "Validates DNS challenges via a user provided custom script",
-            HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/scripting",
+            HelpUrl = "https://docs.autossl.com/dns/providers/scripting",
             PropagationDelaySeconds = 60,
             ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{ Key="createscriptpath", Name="Create Script Path", IsRequired=true , IsCredential=false},

--- a/src/Certify.Locales/ConfigResources.Designer.cs
+++ b/src/Certify.Locales/ConfigResources.Designer.cs
@@ -80,7 +80,7 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to https://certifytheweb.com/downloads/version.json.
+        ///   Looks up a localized string similar to https://autossl.com/downloads/version.json.
         /// </summary>
         public static string AppUpdateCheckURI {
             get {

--- a/src/Certify.Locales/ConfigResources.resx
+++ b/src/Certify.Locales/ConfigResources.resx
@@ -139,7 +139,7 @@ This software uses the following Open Source software (or significant portions o
     <value>You are using the latest version.</value>
   </data>
   <data name="AppUpdateCheckURI" xml:space="preserve">
-    <value>https://certifytheweb.com/downloads/version.json</value>
+    <value>https://autossl.com/downloads/version.json</value>
     <comment>Do not translate</comment>
   </data>
   <data name="AppWebsiteURL" xml:space="preserve">

--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -115,7 +115,7 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This version is free for evaluation and will manage a limited number of certificates. To remove this limitation please purchase a registration key at https://certifytheweb.com/register. Registered users can get support by emailing support@certifytheweb.com.
+        ///   Looks up a localized string similar to This version is free for evaluation and will manage a limited number of certificates. To remove this limitation please purchase a registration key at https://autossl.com/register. Registered users can get support by emailing support@autossl.com.
         /// </summary>
         public static string AboutControl_TrialDetailLabel {
             get {
@@ -268,7 +268,7 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To add this server to your dashboard, provide your https://certifytheweb.com/profile sign in details or register a new account:.
+        ///   Looks up a localized string similar to To add this server to your dashboard, provide your https://autossl.com/profile sign in details or register a new account:.
         /// </summary>
         public static string Dashboard_AddIntro {
             get {
@@ -628,7 +628,7 @@ namespace Certify.Locales {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Your license key has expired. Some features will be reduced or unavailable. Please Sign In to https://certifytheweb.com and renew your license key, then re-open the app.
+        ///   Looks up a localized string similar to Your license key has expired. Some features will be reduced or unavailable. Please Sign In to https://autossl.com and renew your license key, then re-open the app.
         /// </summary>
         public static string GettingStarted_LicenseExpiredMessage {
             get {
@@ -637,7 +637,7 @@ namespace Certify.Locales {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to You are using the unlicensed Community Edition. If you are using this application within a business or funded organisation you should purchase a license key when you have completed your evaluation, then use About > Enter Key.. to activate. Visit certifytheweb.com/register for more information.
+        ///   Looks up a localized string similar to You are using the unlicensed Community Edition. If you are using this application within a business or funded organisation you should purchase a license key when you have completed your evaluation, then use About > Enter Key.. to activate. Visit autossl.com/register for more information.
         /// </summary>
         public static string GettingStarted_LicenseNotActivatedMessage {
             get {
@@ -655,7 +655,7 @@ namespace Certify.Locales {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Looking to manage and monitor many certificates over many servers? Check out our new product Certify Management Hub - details at https://docs.certifytheweb.com.
+        ///   Looks up a localized string similar to Looking to manage and monitor many certificates over many servers? Check out our new product Certify Management Hub - details at https://docs.autossl.com.
         /// </summary>
         public static string GettingStarted_ManagementHubIntro {
             get {
@@ -664,7 +664,7 @@ namespace Certify.Locales {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to For more information, documentation, community discussions and support options, see https://certifytheweb.com.
+        ///   Looks up a localized string similar to For more information, documentation, community discussions and support options, see https://autossl.com.
         /// </summary>
         public static string GettingStarted_MoreInfoIntro {
             get {
@@ -772,7 +772,7 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certify Certificate Manager Contributors （https://certifytheweb.com）.
+        ///   Looks up a localized string similar to Certify Certificate Manager Contributors （https://autossl.com）.
         /// </summary>
         public static string LanguageAuthor {
             get {
@@ -799,7 +799,7 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to IIS Was not detected on this server, important functionality will be unavailable. If you know IIS is installed and working on this server, please report this error to support@certifytheweb.com providing details of your server Operating System version and IIS versions.
+        ///   Looks up a localized string similar to IIS Was not detected on this server, important functionality will be unavailable. If you know IIS is installed and working on this server, please report this error to support@autossl.com providing details of your server Operating System version and IIS versions.
         /// </summary>
         public static string MainWindow_IISNotAvailable {
             get {
@@ -1901,7 +1901,7 @@ namespace Certify.Locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Thanks for submitting feedback to our developers. Please email support@certifytheweb.com if you have a question..
+        ///   Looks up a localized string similar to Thanks for submitting feedback to our developers. Please email support@autossl.com if you have a question..
         /// </summary>
         public static string Send_Feedback_Tip {
             get {

--- a/src/Certify.Locales/SR.es-ES.resx
+++ b/src/Certify.Locales/SR.es-ES.resx
@@ -259,7 +259,7 @@
     <value>Contraseña</value>
   </data>
   <data name="AboutControl_TrialDetailLabel" xml:space="preserve">
-    <value>Esta versión es gratuita para evaluación y gestionará un número limitado de certificados. Para eliminar esta limitación, compre una clave de registro en https://certifytheweb.com/register. Los usuarios registrados pueden obtener asistencia enviando un correo electrónico a support@certifytheweb.com </value>
+    <value>Esta versión es gratuita para evaluación y gestionará un número limitado de certificados. Para eliminar esta limitación, compre una clave de registro en https://autossl.com/register. Los usuarios registrados pueden obtener asistencia enviando un correo electrónico a support@autossl.com </value>
   </data>
   <data name="AboutControl_RegistrationTypeLabel" xml:space="preserve">
     <value>No Registrado</value>
@@ -524,7 +524,7 @@
     <value>Esto renovará los certificados para todos los elementos de auto-renovación. ¿Proceder?</value>
   </data>
   <data name="MainWindow_IISNotAvailable" xml:space="preserve">
-    <value>No se detectó IIS en este servidor, una serie de características importantes no estarán disponible. Si IIS está instalado y ejecutándose en este servidor, informe este error a support@certifytheweb.com proporcionando detalles de la versión del sistema operativo del servidor y las versiones de IIS.</value>
+    <value>No se detectó IIS en este servidor, una serie de características importantes no estarán disponible. Si IIS está instalado y ejecutándose en este servidor, informe este error a support@autossl.com proporcionando detalles de la versión del sistema operativo del servidor y las versiones de IIS.</value>
   </data>
   <data name="MainWindow_GetStartGuideWithNewCert" xml:space="preserve">
     <value>Comience registrando un nuevo contacto, luego puede comenzar a solicitar certificados.</value>
@@ -536,7 +536,7 @@
     <value>[Edición de la comunidad] </value>
   </data>
   <data name="LanguageAuthor" xml:space="preserve">
-    <value>Colaboradores de Certify Certificate Manager https://certifytheweb.com</value>
+    <value>Colaboradores de Certify Certificate Manager https://autossl.com</value>
   </data>
   <data name="About_LanguageTranslator" xml:space="preserve">
     <value>Traductor de idiomas actual:</value>
@@ -617,7 +617,7 @@
     <value>Crear una nueva cuenta</value>
   </data>
   <data name="Dashboard_AddIntro" xml:space="preserve">
-    <value>Para agregar este servidor a su panel, proporcione sus https://certifytheweb.com/profile detalles de inicio de sesión o registre una nueva cuenta: </value>
+    <value>Para agregar este servidor a su panel, proporcione sus https://autossl.com/profile detalles de inicio de sesión o registre una nueva cuenta: </value>
   </data>
   <data name="ScheduledTaskConfig_UseBackgroundService" xml:space="preserve">
     <value>Usar servicio en segundo plano (se ejecuta como sistema local) </value>

--- a/src/Certify.Locales/SR.ja-JP.resx
+++ b/src/Certify.Locales/SR.ja-JP.resx
@@ -511,7 +511,7 @@
     <value>すべての自動更新アイテムの証明書が更新されます。 続行しますか？</value>
   </data>
   <data name="MainWindow_IISNotAvailable" xml:space="preserve">
-    <value>このサーバーでIISが検出されなかったため、重要な機能は使用できなくなりました。 IISがインストールされ、このサーバーで動作していることが分かっている場合は、サーバーのオペレーティングシステムのバージョンとIISのバージョンの詳細を提供する support@certifytheweb.com にこのエラーを報告してください</value>
+    <value>このサーバーでIISが検出されなかったため、重要な機能は使用できなくなりました。 IISがインストールされ、このサーバーで動作していることが分かっている場合は、サーバーのオペレーティングシステムのバージョンとIISのバージョンの詳細を提供する support@autossl.com にこのエラーを報告してください</value>
   </data>
   <data name="MainWindow_GetStartGuideWithNewCert" xml:space="preserve">
     <value>新しい連絡先を登録すると、証明書の要求を開始できます。</value>
@@ -523,7 +523,7 @@
     <value>[コミュニティ エディション]</value>
   </data>
   <data name="LanguageAuthor" xml:space="preserve">
-    <value>Certify マネージャー コントリビューター（https://certifytheweb.com）</value>
+    <value>Certify マネージャー コントリビューター（https://autossl.com）</value>
   </data>
   <data name="About_LanguageTranslator" xml:space="preserve">
     <value>現在の言語の翻訳:</value>
@@ -604,7 +604,7 @@
     <value>新しいアカウントを作成します</value>
   </data>
   <data name="Dashboard_AddIntro" xml:space="preserve">
-    <value>このサーバーをダッシュボードに追加するには、https://certifytheweb.com/profile にサインインして詳細を入力するか、新しいアカウントを登録します。</value>
+    <value>このサーバーをダッシュボードに追加するには、https://autossl.com/profile にサインインして詳細を入力するか、新しいアカウントを登録します。</value>
   </data>
   <data name="ScheduledTaskConfig_UseBackgroundService" xml:space="preserve">
     <value>バック グラウンド サービスを利用 (ローカル システムとして実行) </value>

--- a/src/Certify.Locales/SR.nb-NO.resx
+++ b/src/Certify.Locales/SR.nb-NO.resx
@@ -504,7 +504,7 @@
     <value>Dette fornyer sertifikater for alle automatisk fornyede elementer. Fortsette?</value>
   </data>
   <data name="MainWindow_IISNotAvailable" xml:space="preserve">
-    <value>IIS ble ikke oppdaget på denne serveren, viktig funksjonalitet vil ikke være tilgjengelig. Hvis du vet at IIS er installert og jobber på denne serveren, vennligst rapporter denne feilen til support@certifytheweb.com, og gi detaljer om serverens operativsystemversjon og IIS-versjoner</value>
+    <value>IIS ble ikke oppdaget på denne serveren, viktig funksjonalitet vil ikke være tilgjengelig. Hvis du vet at IIS er installert og jobber på denne serveren, vennligst rapporter denne feilen til support@autossl.com, og gi detaljer om serverens operativsystemversjon og IIS-versjoner</value>
   </data>
   <data name="MainWindow_GetStartGuideWithNewCert" xml:space="preserve">
     <value>Kom i gang ved å registrere en ny kontakt, så kan du begynne å be om sertifikater.</value>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -201,7 +201,7 @@
     <value>Senha</value>
   </data>
   <data name="AboutControl_TrialDetailLabel" xml:space="preserve">
-    <value>Esta versão é gratuita para avaliação e gerenciará um número limitado de certificados. Para remover essa limitação, compre uma chave de registro em https://certifytheweb.com/register. Usuários registrados podem obter suporte enviando um e-mail para support@certifytheweb.com</value>
+    <value>Esta versão é gratuita para avaliação e gerenciará um número limitado de certificados. Para remover essa limitação, compre uma chave de registro em https://autossl.com/register. Usuários registrados podem obter suporte enviando um e-mail para support@autossl.com</value>
   </data>
   <data name="AboutControl_RegistrationTypeLabel" xml:space="preserve">
     <value>Não registrado</value>
@@ -466,7 +466,7 @@
     <value>Isso renovará os certificados para todos os itens de auto-renovação. Prosseguir?</value>
   </data>
   <data name="MainWindow_IISNotAvailable" xml:space="preserve">
-    <value>IIS não foi detectado neste servidor; vários recursos importantes não estarão disponíveis. Se o IIS estiver instalado e em execução neste servidor, informe esse erro para support@certifytheweb.com fornecendo detalhes da versão do sistema operacional do servidor e das versões do IIS.</value>
+    <value>IIS não foi detectado neste servidor; vários recursos importantes não estarão disponíveis. Se o IIS estiver instalado e em execução neste servidor, informe esse erro para support@autossl.com fornecendo detalhes da versão do sistema operacional do servidor e das versões do IIS.</value>
   </data>
   <data name="MainWindow_GetStartGuideWithNewCert" xml:space="preserve">
     <value>Comece registrando um novo contato, depois você pode começar a solicitar certificados.</value>
@@ -562,13 +562,13 @@
     <value>Versões do IIS abaixo da 8.0 não possuem suporte a SNI. Isso significa que apenas um certificado pode ser usado por endereço IP para https padrão. Se você precisar de mais de um único certificado, será necessário garantir que cada associação de certificado esteja associada ao seu próprio endereço IP, caso contrário você poderá encontrar conflitos de associação.</value>
   </data>
   <data name="GettingStarted_LicenseExpiredMessage" xml:space="preserve">
-    <value>Sua chave de licença expirou. Alguns recursos serão reduzidos ou ficarão indisponíveis. Faça login em https://certifytheweb.com e renove sua chave de licença, depois reabra o aplicativo.</value>
+    <value>Sua chave de licença expirou. Alguns recursos serão reduzidos ou ficarão indisponíveis. Faça login em https://autossl.com e renove sua chave de licença, depois reabra o aplicativo.</value>
   </data>
   <data name="GettingStarted_LicenseNotActivatedTitle" xml:space="preserve">
     <value>Licença não ativada</value>
   </data>
   <data name="GettingStarted_LicenseNotActivatedMessage" xml:space="preserve">
-    <value>Você está usando a Community Edition sem licença. Se estiver usando este aplicativo em uma empresa ou organização financiada, você deve adquirir uma chave de licença quando concluir sua avaliação e então usar Sobre &gt; Inserir chave.. para ativar. Visite certifytheweb.com/register para mais informações.</value>
+    <value>Você está usando a Community Edition sem licença. Se estiver usando este aplicativo em uma empresa ou organização financiada, você deve adquirir uma chave de licença quando concluir sua avaliação e então usar Sobre &gt; Inserir chave.. para ativar. Visite autossl.com/register para mais informações.</value>
   </data>
   <data name="GettingStarted_ManagementHubIntro" xml:space="preserve">
     <value>Quer gerenciar e monitorar muitos certificados em vários servidores? Conheça o AutSSLHub - detalhes em https://autoip.com.br</value>

--- a/src/Certify.Locales/SR.tr-TR.resx
+++ b/src/Certify.Locales/SR.tr-TR.resx
@@ -175,7 +175,7 @@
     <value>Geribildirim yolla</value>
   </data>
   <data name="Send_Feedback_Tip" xml:space="preserve">
-    <value>Geliştiricilerimize geri bildirim gönderdiğiniz için teşekkür ederiz. Bir sorunuz varsa lütfen support@certifytheweb.com adresine e-posta gönderin.</value>
+    <value>Geliştiricilerimize geri bildirim gönderdiğiniz için teşekkür ederiz. Bir sorunuz varsa lütfen support@autossl.com adresine e-posta gönderin.</value>
   </data>
   <data name="Send_Feedback_Quest" xml:space="preserve">
     <value>Önerin var mı?</value>
@@ -259,7 +259,7 @@
     <value>Parola</value>
   </data>
   <data name="AboutControl_TrialDetailLabel" xml:space="preserve">
-    <value>Bu sürüm değerlendirme için ücretsizdir ve sınırlı sayıda sertifikayı yönetecektir. Bu sınırlamayı kaldırmak için lütfen https://certifytheweb.com/register adresinden bir kayıt anahtarı satın alın. Kayıtlı kullanıcılar support@certifytheweb.com adresine e-posta göndererek destek alabilirler.</value>
+    <value>Bu sürüm değerlendirme için ücretsizdir ve sınırlı sayıda sertifikayı yönetecektir. Bu sınırlamayı kaldırmak için lütfen https://autossl.com/register adresinden bir kayıt anahtarı satın alın. Kayıtlı kullanıcılar support@autossl.com adresine e-posta göndererek destek alabilirler.</value>
   </data>
   <data name="AboutControl_RegistrationTypeLabel" xml:space="preserve">
     <value>Kayıtlı değil</value>
@@ -522,7 +522,7 @@
     <value>Bu, otomatik olarak yenilenen tüm öğeler için sertifikaları yenileyecektir. Devam etmek istiyor musunuz?</value>
   </data>
   <data name="MainWindow_IISNotAvailable" xml:space="preserve">
-    <value>IIS Bu sunucuda algılanmadı, önemli işlevler kullanılamayacak. IIS'nin bu sunucuda kurulu olduğunu ve çalıştığını biliyorsanız, lütfen bu hatayı sunucunuzun İşletim Sistemi sürümünün ve IIS sürümlerinin ayrıntılarını vererek support@certifytheweb.com adresine bildirin.</value>
+    <value>IIS Bu sunucuda algılanmadı, önemli işlevler kullanılamayacak. IIS'nin bu sunucuda kurulu olduğunu ve çalıştığını biliyorsanız, lütfen bu hatayı sunucunuzun İşletim Sistemi sürümünün ve IIS sürümlerinin ayrıntılarını vererek support@autossl.com adresine bildirin.</value>
   </data>
   <data name="MainWindow_GetStartGuideWithNewCert" xml:space="preserve">
     <value>Yeni bir kişi kaydederek başlayın, ardından sertifika istemeye başlayabilirsiniz.</value>
@@ -534,7 +534,7 @@
     <value>[Topluluk Sürümü]</value>
   </data>
   <data name="LanguageAuthor" xml:space="preserve">
-    <value>Certify Yöneticisi'ne Katkıda Bulunanlar（https://certifytheweb.com）</value>
+    <value>Certify Yöneticisi'ne Katkıda Bulunanlar（https://autossl.com）</value>
   </data>
   <data name="About_LanguageTranslator" xml:space="preserve">
     <value>Mevcut Dil Tercümanı:</value>
@@ -615,7 +615,7 @@
     <value>Yeni bir hesap oluştur</value>
   </data>
   <data name="Dashboard_AddIntro" xml:space="preserve">
-    <value>Bu sunucuyu kontrol panelinize eklemek için https://certifytheweb.com/profile oturum açma bilgilerinizi sağlayın veya yeni bir hesap açın:</value>
+    <value>Bu sunucuyu kontrol panelinize eklemek için https://autossl.com/profile oturum açma bilgilerinizi sağlayın veya yeni bir hesap açın:</value>
   </data>
   <data name="ScheduledTaskConfig_UseBackgroundService" xml:space="preserve">
     <value>Arka Plan Hizmetini Kullan (Yerel Sistem olarak çalışır)</value>

--- a/src/Certify.Locales/SR.zh-Hans.resx
+++ b/src/Certify.Locales/SR.zh-Hans.resx
@@ -175,7 +175,7 @@
     <value>提交反馈</value>
   </data>
   <data name="Send_Feedback_Tip" xml:space="preserve">
-    <value>感谢您向开发团队反馈问题。如有疑问，请发邮件至 support@certifytheweb.com</value>
+    <value>感谢您向开发团队反馈问题。如有疑问，请发邮件至 support@autossl.com</value>
   </data>
   <data name="Send_Feedback_Quest" xml:space="preserve">
     <value>您有什么建议吗？</value>
@@ -259,7 +259,7 @@
     <value>密码</value>
   </data>
   <data name="AboutControl_TrialDetailLabel" xml:space="preserve">
-    <value>当前版本为免费试用版，仅可管理有限数量的证书。如需解除限制，请前往 https://certifytheweb.com/register 购买注册密钥。已注册用户可通过 support@certifytheweb.com 获取支持</value>
+    <value>当前版本为免费试用版，仅可管理有限数量的证书。如需解除限制，请前往 https://autossl.com/register 购买注册密钥。已注册用户可通过 support@autossl.com 获取支持</value>
   </data>
   <data name="AboutControl_RegistrationTypeLabel" xml:space="preserve">
     <value>未注册</value>
@@ -525,7 +525,7 @@
     <value>这将为所有自动续期项目续签证书（如适用），确定继续？</value>
   </data>
   <data name="MainWindow_IISNotAvailable" xml:space="preserve">
-    <value>未检测到IIS，部分重要功能将无法使用，如果您确定本服务器已安装且正常运行IIS，请将您的操作系统和IIS版本详情发送至 support@certifytheweb.com 以反馈此问题</value>
+    <value>未检测到IIS，部分重要功能将无法使用，如果您确定本服务器已安装且正常运行IIS，请将您的操作系统和IIS版本详情发送至 support@autossl.com 以反馈此问题</value>
   </data>
   <data name="MainWindow_GetStartGuideWithNewCert" xml:space="preserve">
     <value>请先注册新联系人，即可开始申请证书</value>
@@ -537,7 +537,7 @@
     <value> [社区版]</value>
   </data>
   <data name="LanguageAuthor" xml:space="preserve">
-    <value>Certify Certificate Manager贡献者（https://certifytheweb.com）</value>
+    <value>Certify Certificate Manager贡献者（https://autossl.com）</value>
   </data>
   <data name="About_LanguageTranslator" xml:space="preserve">
     <value>当前语言翻译：</value>
@@ -618,7 +618,7 @@
     <value>创建新账户</value>
   </data>
   <data name="Dashboard_AddIntro" xml:space="preserve">
-    <value>如需将此服务器添加到您的面板，请填写 https://certifytheweb.com/profile 登录信息或注册新账户：</value>
+    <value>如需将此服务器添加到您的面板，请填写 https://autossl.com/profile 登录信息或注册新账户：</value>
   </data>
   <data name="ScheduledTaskConfig_UseBackgroundService" xml:space="preserve">
     <value>使用后台服务（以本地系统帐户运行）</value>

--- a/src/Certify.Locales/SR.zh-Hant.resx
+++ b/src/Certify.Locales/SR.zh-Hant.resx
@@ -175,7 +175,7 @@
     <value>意見回饋</value>
   </data>
   <data name="Send_Feedback_Tip" xml:space="preserve">
-    <value>感謝您提供意見回饋，如有任何疑問，請寄信至 support@certifytheweb.com</value>
+    <value>感謝您提供意見回饋，如有任何疑問，請寄信至 support@autossl.com</value>
   </data>
   <data name="Send_Feedback_Quest" xml:space="preserve">
     <value>您有任何建議嗎？</value>
@@ -259,7 +259,7 @@
     <value>密碼</value>
   </data>
   <data name="AboutControl_TrialDetailLabel" xml:space="preserve">
-    <value>本版本僅供試用，最多可管理有限數量的憑證。如需移除限制，請至 https://certifytheweb.com/register 購買註冊金鑰，註冊用戶如需支援請寄信至 support@certifytheweb.com</value>
+    <value>本版本僅供試用，最多可管理有限數量的憑證。如需移除限制，請至 https://autossl.com/register 購買註冊金鑰，註冊用戶如需支援請寄信至 support@autossl.com</value>
   </data>
   <data name="AboutControl_RegistrationTypeLabel" xml:space="preserve">
     <value>尚未註冊</value>
@@ -525,7 +525,7 @@
     <value>這會為所有設定自動續期的項目進行續期，確定要繼續？</value>
   </data>
   <data name="MainWindow_IISNotAvailable" xml:space="preserve">
-    <value>本伺服器未偵測到 IIS，部分重要功能將無法使用。若確定本機已安裝並啟用 IIS，請提供您的作業系統與 IIS 版本細節回報至 support@certifytheweb.com</value>
+    <value>本伺服器未偵測到 IIS，部分重要功能將無法使用。若確定本機已安裝並啟用 IIS，請提供您的作業系統與 IIS 版本細節回報至 support@autossl.com</value>
   </data>
   <data name="MainWindow_GetStartGuideWithNewCert" xml:space="preserve">
     <value>請先註冊新聯絡人，即可開始申請憑證</value>
@@ -537,7 +537,7 @@
     <value> [社群版]</value>
   </data>
   <data name="LanguageAuthor" xml:space="preserve">
-    <value>Certify Certificate Manager 貢獻者 （https://certifytheweb.com）</value>
+    <value>Certify Certificate Manager 貢獻者 （https://autossl.com）</value>
   </data>
   <data name="About_LanguageTranslator" xml:space="preserve">
     <value>目前語言譯者：</value>
@@ -618,7 +618,7 @@
     <value>建立新帳號</value>
   </data>
   <data name="Dashboard_AddIntro" xml:space="preserve">
-    <value>若要將此伺服器新增至您的儀表板，請輸入您的 https://certifytheweb.com/profile 登入資訊，或註冊新帳號：</value>
+    <value>若要將此伺服器新增至您的儀表板，請輸入您的 https://autossl.com/profile 登入資訊，或註冊新帳號：</value>
   </data>
   <data name="ScheduledTaskConfig_UseBackgroundService" xml:space="preserve">
     <value>使用背景服務（以 Local System 執行）</value>

--- a/src/Certify.Models/Shared/DocumentationLinks.cs
+++ b/src/Certify.Models/Shared/DocumentationLinks.cs
@@ -2,7 +2,7 @@
 {
     public static class DocumentationLinks
     {
-        private const string DOCS_BASE = "https://docs.certifytheweb.com/docs";
+        private const string DOCS_BASE = "https://docs.autossl.com";
 
         public const string GETTING_STARTED = DOCS_BASE + "/intro";
         public const string ABOUT_LETSENCRYPT = DOCS_BASE + "/letsencrypt";

--- a/src/Certify.Providers/DNS/AWSRoute53/DnsProviderAWSRoute53.cs
+++ b/src/Certify.Providers/DNS/AWSRoute53/DnsProviderAWSRoute53.cs
@@ -40,7 +40,7 @@ namespace Certify.Providers.DNS.AWSRoute53
             Id = "DNS01.API.Route53",
             Title = "Amazon Route 53 DNS API",
             Description = "Validates via Route 53 APIs using IAM service credentials",
-            HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/awsroute53",
+            HelpUrl = "https://docs.autossl.com/dns/providers/awsroute53",
             PropagationDelaySeconds = 60,
             ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{ Key="accesskey",Name="Access Key", IsRequired=true, IsPassword=false },

--- a/src/Certify.Providers/DNS/AcmeDns/AcmeDns/DnsProviderAcmeDns.cs
+++ b/src/Certify.Providers/DNS/AcmeDns/AcmeDns/DnsProviderAcmeDns.cs
@@ -66,7 +66,7 @@ namespace Certify.Providers.DNS.AcmeDns
                     Id = "DNS01.API.AcmeDns",
                     Title = "acme-dns DNS API",
                     Description = "Validates via an acme-dns server using CNAME redirection to an alternative DNS service dedicated to ACME challenge responses.",
-                    HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/acme-dns",
+                    HelpUrl = "https://docs.autossl.com/dns/providers/acme-dns",
                     PropagationDelaySeconds = 5,
                     ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{ Key="api",Name="API Url", IsRequired=true, IsCredential=false, IsPassword=false, Value="https://auth.acme-dns.io", Description="Self hosted API is recommended: https://github.com/joohoi/acme-dns" },

--- a/src/Certify.Providers/DNS/Azure/DnsProviderAzure.cs
+++ b/src/Certify.Providers/DNS/Azure/DnsProviderAzure.cs
@@ -48,7 +48,7 @@ namespace Certify.Providers.DNS.Azure
             Id = "DNS01.API.Azure",
             Title = "Azure DNS API",
             Description = "Validates via Azure DNS APIs using credentials",
-            HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/azuredns",
+            HelpUrl = "https://docs.autossl.com/dns/providers/azuredns",
             PropagationDelaySeconds = 60,
             ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{ Key="service",Name="Azure Service", IsRequired=true, IsPassword=false, IsCredential=true, Value="global", OptionsList="global=Azure Cloud; china=Azure China; germany=Azure Germany (deprecated); usgov=Azure US Government" },

--- a/src/Certify.Providers/DNS/CertifyDns/DnsProviderCertifyDns.cs
+++ b/src/Certify.Providers/DNS/CertifyDns/DnsProviderCertifyDns.cs
@@ -50,11 +50,11 @@ namespace Certify.Providers.DNS.CertifyDns
                 {
                     Id = "DNS01.API.CertifyDns",
                     Title = "Certify DNS",
-                    Description = "Validates DNS Challenges via Certify DNS (a cloud based service provided by certifytheweb.com). This requires the one-time creation of CNAME records per domain.",
-                    HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/certifydns",
+                    Description = "Validates DNS Challenges via Certify DNS (a cloud based service provided by autossl.com). This requires the one-time creation of CNAME records per domain.",
+                    HelpUrl = "https://docs.autossl.com/dns/providers/certifydns",
                     PropagationDelaySeconds = 5,
                     ProviderParameters = new List<ProviderParameter>{
-                        new ProviderParameter{ Key="api",Name="API Url", IsRequired=true, IsCredential=false, IsPassword=false, Value="https://certify-dns.certifytheweb.com", Description="Base URL for a managed version of acme-dns" },
+                        new ProviderParameter{ Key="api",Name="API Url", IsRequired=true, IsCredential=false, IsPassword=false, Value="https://certify-dns.autossl.com", Description="Base URL for a managed version of acme-dns" },
                         new ProviderParameter{ Key="user",Name="API Username", IsRequired=true, IsCredential=true, IsPassword=false,  Description="API Username" },
                         new ProviderParameter{ Key="key",Name="API Key", IsRequired=true, IsCredential=true, IsPassword=false,  Description="API Key" },
 
@@ -203,7 +203,7 @@ namespace Certify.Providers.DNS.CertifyDns
             {
                 // try alternative store name
                 _settingsStoreName = "acmedns";
-                registrationCheck = EnsureExistingRegistration(_settingsStoreName, settingsPath, domainId, apiPrefix, ensureSuffix: "auth.certifytheweb.com");
+                registrationCheck = EnsureExistingRegistration(_settingsStoreName, settingsPath, domainId, apiPrefix, ensureSuffix: "auth.autossl.com");
             }
 
             // return existing if any

--- a/src/Certify.Providers/DNS/CertifyManaged/DnsProviderCertifyManaged.cs
+++ b/src/Certify.Providers/DNS/CertifyManaged/DnsProviderCertifyManaged.cs
@@ -30,7 +30,7 @@ namespace Certify.Providers.DNS.CertifyManaged
                     Id = "DNS01.API.CertifyManaged",
                     Title = "Certify Managed Challenge API",
                     Description = "Performs challenge responses via the Certify Management Hub API.",
-                    HelpUrl = "https://docs.certifytheweb.com/",
+                    HelpUrl = "https://docs.autossl.com/",
                     PropagationDelaySeconds = 60,
                     ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{ Key="api",Name="Management Hub API Url", IsRequired=false, IsCredential=false, IsPassword=false, Description="(leave blank to use current management hub API)" },

--- a/src/Certify.Providers/DNS/Cloudflare/DnsProviderCloudflare.cs
+++ b/src/Certify.Providers/DNS/Cloudflare/DnsProviderCloudflare.cs
@@ -109,7 +109,7 @@ namespace Certify.Providers.DNS.Cloudflare
             Id = "DNS01.API.Cloudflare",
             Title = "Cloudflare DNS API",
             Description = "Validates via Cloudflare DNS APIs using credentials (using API Token or Email + AuthKey pair)",
-            HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/cloudflare",
+            HelpUrl = "https://docs.autossl.com/dns/providers/cloudflare",
             PropagationDelaySeconds = 60,
             ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{Key="emailaddress", Name="Email Address", IsRequired=false, Description="Required if not using API Token" },

--- a/src/Certify.Providers/DNS/DnsMadeEasy/DnsProviderDnsMadeEasy.cs
+++ b/src/Certify.Providers/DNS/DnsMadeEasy/DnsProviderDnsMadeEasy.cs
@@ -66,7 +66,7 @@ namespace Certify.Providers.DNS.DnsMadeEasy
             Id = "DNS01.API.DnsMadeEasy",
             Title = "DnsMadeEasy DNS API (Deprecated - Use Posh-ACME version instead)",
             Description = "Validates via DnsMadeEasy APIs. This provider is deprecated and you should switch to the Posh-ACME version.",
-            HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/dnsmadeeasy",
+            HelpUrl = "https://docs.autossl.com/dns/providers/dnsmadeeasy",
             PropagationDelaySeconds = 120,
             ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{Key="apikey", Name="API Key", IsRequired=true },

--- a/src/Certify.Providers/DNS/GoDaddy/DnsProviderGoDaddy.cs
+++ b/src/Certify.Providers/DNS/GoDaddy/DnsProviderGoDaddy.cs
@@ -71,7 +71,7 @@ namespace Certify.Providers.DNS.GoDaddy
             Id = "DNS01.API.GoDaddy",
             Title = "GoDaddy DNS API",
             Description = "Validates via GoDaddy DNS APIs using credentials. Requires account with 10+ domains hosted on GoDaddy DNS.",
-            HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/godaddy",
+            HelpUrl = "https://docs.autossl.com/dns/providers/godaddy",
             PropagationDelaySeconds = 120,
             ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{ Key="authkey", Name="Auth Key", IsRequired=true },

--- a/src/Certify.Providers/DNS/OVH/DnsProviderOvh.cs
+++ b/src/Certify.Providers/DNS/OVH/DnsProviderOvh.cs
@@ -47,7 +47,7 @@ namespace Certify.Providers.DNS.OVH
                     Id = "DNS01.API.Ovh",
                     Title = "OVH DNS API",
                     Description = "Validates via OVH APIs using credentials generated from the token creation page.",
-                    HelpUrl = "https://docs.certifytheweb.com/docs/dns/providers/ovh",
+                    HelpUrl = "https://docs.autossl.com/dns/providers/ovh",
                     PropagationDelaySeconds = 120,
                     ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{Key=ApplicationKeyParamKey, Name="Application Key", IsRequired=true },

--- a/src/Certify.Server/Certify.Server.Hub.Api/Startup.cs
+++ b/src/Certify.Server/Certify.Server.Hub.Api/Startup.cs
@@ -99,7 +99,7 @@ namespace Certify.Server.Hub.Api
                 {
                     Title = "Certify Management Hub API",
                     Version = "v1",
-                    Description = "The Certify Management Hub API provides a certificate services API for use in UI, devops, CI/CD, middleware etc. See certifytheweb.com for more details. Routes marked /internal/ may change regularly and are not intended for general use."
+                    Description = "The Certify Management Hub API provides a certificate services API for use in UI, devops, CI/CD, middleware etc. See autossl.com for more details. Routes marked /internal/ may change regularly and are not intended for general use."
                 });
 
                 c.UseAllOfToExtendReferenceSchemas();

--- a/src/Certify.Service/APIHost.cs
+++ b/src/Certify.Service/APIHost.cs
@@ -23,7 +23,7 @@ namespace Certify.Service
                 context.Request.CreateResponse(HttpStatusCode.InternalServerError,
                 new
                 {
-                    Message = $"An internal error has occurred. If this problem happens regularly please report it to support@certifytheweb.com: {context.Exception?.Message} {context.Exception.Source} {context.Exception.StackTrace}",
+                    Message = $"An internal error has occurred. If this problem happens regularly please report it to support@autossl.com: {context.Exception?.Message} {context.Exception.Source} {context.Exception.StackTrace}",
                     Exception = context.Exception
                 },
                 JsonMediaTypeFormatter.DefaultMediaType

--- a/src/Certify.Shared.Extensions/Providers/DnsProviderPoshACME.cs
+++ b/src/Certify.Shared.Extensions/Providers/DnsProviderPoshACME.cs
@@ -156,7 +156,7 @@ namespace Certify.Core.Management.Challenges.DNS
             Id = "DNS01.Powershell",
             Title = "Powershell/PoshACME DNS",
             Description = "Validates DNS challenges via a user provided custom powershell script",
-            HelpUrl = "https://docs.certifytheweb.com/docs/dns/validation",
+            HelpUrl = "https://docs.autossl.com/dns/validation",
             PropagationDelaySeconds = DefaultPropagationDelay,
             ProviderParameters = new List<ProviderParameter>{
                         new ProviderParameter{ Key="args",Name="Script arguments", IsRequired=false, IsPassword=false, Value=DefaultPropagationDelay.ToString(), IsCredential=false },

--- a/src/Certify.Shared.Extensions/Scripts/Common/Export PFX to Apache.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/Common/Export PFX to Apache.ps1
@@ -3,7 +3,7 @@
 
 param($result)
 
-# script example adapted from https://community.certifytheweb.com/t/filezilla-server-ps-script/141/8
+# script example adapted from https://community.autossl.com/t/filezilla-server-ps-script/141/8
 
 # Alias to your OpenSSL install
 set-alias opensslcmd "C:\Tools\OpenSSL\openssl.exe" 

--- a/src/Certify.Shared.Extensions/Scripts/Common/MSExchangeEnableServices.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/Common/MSExchangeEnableServices.ps1
@@ -2,7 +2,7 @@
 # To use this script copy it to another location and modify as required
 
 # This script enables the use of the newly retrieved and stored certificate with common Exchange services
-# For more script info see https://docs.certifytheweb.com/docs/script-hooks.html
+# For more script info see https://docs.autossl.com/script-hooks.html
 
 param($result)
 

--- a/src/Certify.Shared.Extensions/Scripts/Common/RDPGatewayServices.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/Common/RDPGatewayServices.ps1
@@ -2,7 +2,7 @@
 # To use this script copy it to another location and modify as required
 
 # Enable certificate for RDP Gateway
-# For more script info see https://docs.certifytheweb.com/docs/script-hooks.html
+# For more script info see https://docs.autossl.com/script-hooks.html
 
 param($result)
 

--- a/src/Certify.Shared.Extensions/Scripts/Common/RDPListenerService.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/Common/RDPListenerService.ps1
@@ -2,7 +2,7 @@
 # To use this script copy it to another location and modify as required
 
 # Enable certificate for RDP Listener Service
-# For more script info see https://docs.certifytheweb.com/docs/script-hooks.html
+# For more script info see https://docs.autossl.com/script-hooks.html
 
 param($result)
 

--- a/src/Certify.Shared.Extensions/Scripts/Common/WebManagementService.ps1
+++ b/src/Certify.Shared.Extensions/Scripts/Common/WebManagementService.ps1
@@ -7,7 +7,7 @@
 # - then sets the associated service port ssl binding to the new cert
 # - then updates the registry key value used by the IIS management UI for the Web Management Service ot the matching cert thumbprint (as binary value)
 
-# For more script info see https://docs.certifytheweb.com/docs/script-hooks.html
+# For more script info see https://docs.autossl.com/script-hooks.html
 
 param($result)
 

--- a/src/Certify.Tests/Certify.Core.Tests.Integration/CertRequestTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/CertRequestTests.cs
@@ -649,7 +649,7 @@ namespace Certify.Core.Tests
                 AccountKey = ConfigSettings["TestAuthTokenPrivateKey"],
                 AccountURI = ConfigSettings["TestAuthTokenAccountURI"],
                 Title = "Dev",
-                Email = "test@certifytheweb.com",
+                Email = "test@autossl.com",
                 CertificateAuthorityId = ConfigSettings["TestAuthTokenCA"],
                 StorageKey = "dev"
             };

--- a/src/Certify.Tests/Certify.Core.Tests.Integration/CertifyManagerTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/CertifyManagerTests.cs
@@ -99,7 +99,7 @@ namespace Certify.Core.Tests
                 AccountKey = "",
                 AccountURI = "",
                 Title = "Dev",
-                Email = "test@certifytheweb.com",
+                Email = "test@autossl.com",
                 CertificateAuthorityId = "badca.com",
                 StorageKey = "dev",
                 IsStagingAccount = true,

--- a/src/Certify.Tests/Certify.Core.Tests.Integration/IntegrationTestBase.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Integration/IntegrationTestBase.cs
@@ -13,7 +13,7 @@ namespace Certify.Core.Tests
     {
         public Dictionary<string, string> ConfigSettings = new Dictionary<string, string>();
 
-        public string PrimaryTestDomain = "test.certifytheweb.com"; // TODO: get this from debug config as it changes per dev machine
+        public string PrimaryTestDomain = "test.autossl.com"; // TODO: get this from debug config as it changes per dev machine
         public string PrimaryWebRootPath = @"c:\inetpub\wwwroot\";
 
         private string _testConfigPath = @"c:\temp\Certify\TestConfigSettings.json";

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/CertifyManagerAccountTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/CertifyManagerAccountTests.cs
@@ -436,7 +436,7 @@ namespace Certify.Core.Tests.Unit
                 AccountKey = "",
                 AccountURI = "",
                 Title = "Dev",
-                Email = "test@certifytheweb.com",
+                Email = "test@autossl.com",
                 CertificateAuthorityId = _customCa.Id,
                 StorageKey = "dev",
                 IsStagingAccount = true,
@@ -446,7 +446,7 @@ namespace Certify.Core.Tests.Unit
             var dummyManagedCert = (new ManagedCertificate { UseStagingMode = true });
             var caAccount = await _certifyManager.GetAccountDetails(dummyManagedCert);
             Assert.IsNotNull(caAccount, "Expected result of CertifyManager.GetAccountDetails() to not be null");
-            Assert.AreEqual("test@certifytheweb.com", caAccount.Email);
+            Assert.AreEqual("test@autossl.com", caAccount.Email);
 
             _certifyManager.OverrideAccountDetails = null;
         }

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsQueryTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/DnsQueryTests.cs
@@ -25,7 +25,7 @@ namespace Certify.Core.Tests.Unit
             result = await net.CheckDNS(log, "cloudapp.net");
             Assert.IsFalse(result.All(r => r.IsSuccess), "Valid domain that does not resolve to an IP Address does not throw an error");
 
-            // certifytheweb.com = no CAA records
+            // autossl.com = no CAA records
             result = await net.CheckDNS(log, "webprofusion.com");
             Assert.IsTrue(result.All(r => r.IsSuccess), "CAA records are not required");
 

--- a/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/MiscAcmeTests.cs
+++ b/src/Certify.Tests/Certify.Core.Tests.Unit/Tests/MiscAcmeTests.cs
@@ -26,15 +26,15 @@ namespace Certify.Core.Tests.Unit
             var directoryJson = """
                  
                 {
-                  "newNonce": "https://acme.dev.certifytheweb.com/v2/newNonce",
-                  "newAccount": "https://acme.dev.certifytheweb.com/v2/newAccount",
-                  "newOrder": "https://acme.dev.certifytheweb.com/v2/newOrder",
-                  "revokeCert": "https://acme.dev.certifytheweb.com/v2/revokeCert",
-                  "keyChange": "https://acme.dev.certifytheweb.com/v2/keyChange",
+                  "newNonce": "https://acme.dev.autossl.com/v2/newNonce",
+                  "newAccount": "https://acme.dev.autossl.com/v2/newAccount",
+                  "newOrder": "https://acme.dev.autossl.com/v2/newOrder",
+                  "revokeCert": "https://acme.dev.autossl.com/v2/revokeCert",
+                  "keyChange": "https://acme.dev.autossl.com/v2/keyChange",
                   "meta": {
-                    "termsOfService": "https://acme.dev.certifytheweb.com/v2/tc.pdf",
-                    "website": "https://certifytheweb.com",
-                    "caaIdentities": ["certifytheweb.com"],
+                    "termsOfService": "https://acme.dev.autossl.com/v2/tc.pdf",
+                    "website": "https://autossl.com",
+                    "caaIdentities": ["autossl.com"],
                     "externalAccountRequired": false
                   }
                 }
@@ -148,15 +148,15 @@ namespace Certify.Core.Tests.Unit
             var directoryJson = """
                  
                 {
-                  "newNonce": "https://acme.dev.certifytheweb.com/v2/newNonce",
-                  "newAccount": "https://acme.dev.certifytheweb.com/v2/newAccount",
-                  "newOrder": "https://acme.dev.certifytheweb.com/v2/newOrder",
-                  "revokeCert": "https://acme.dev.certifytheweb.com/v2/revokeCert",
-                  "keyChange": "https://acme.dev.certifytheweb.com/v2/keyChange",
+                  "newNonce": "https://acme.dev.autossl.com/v2/newNonce",
+                  "newAccount": "https://acme.dev.autossl.com/v2/newAccount",
+                  "newOrder": "https://acme.dev.autossl.com/v2/newOrder",
+                  "revokeCert": "https://acme.dev.autossl.com/v2/revokeCert",
+                  "keyChange": "https://acme.dev.autossl.com/v2/keyChange",
                   "meta": {
-                    "termsOfService": "https://acme.dev.certifytheweb.com/v2/tc.pdf",
-                    "website": "https://certifytheweb.com",
-                    "caaIdentities": ["certifytheweb.com"],
+                    "termsOfService": "https://acme.dev.autossl.com/v2/tc.pdf",
+                    "website": "https://autossl.com",
+                    "caaIdentities": ["autossl.com"],
                     "externalAccountRequired": false
                   }
                 }

--- a/src/Certify.Tests/Certify.Service.Tests.Integration/AccountTests.cs
+++ b/src/Certify.Tests/Certify.Service.Tests.Integration/AccountTests.cs
@@ -39,7 +39,7 @@ namespace Certify.Service.Tests.Integration
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             throw new NotImplementedException("Implement Update Account");
-            //var result = await _client.Update(new Models.ContactRegistration { EmailAddress = "certify@certifytheweb.com", AgreedToTermsAndConditions = true });
+            //var result = await _client.Update(new Models.ContactRegistration { EmailAddress = "certify@autossl.com", AgreedToTermsAndConditions = true });
 
         }
     }

--- a/src/Certify.UI.Shared/Controls/GettingStarted.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/GettingStarted.xaml.cs
@@ -28,7 +28,7 @@ namespace Certify.UI.Controls
             d.ShowDialog();
         }
 
-        private void ViewDashboard_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://dash.certifytheweb.com/");
+        private void ViewDashboard_Click(object sender, RoutedEventArgs e) => Utils.Helpers.LaunchBrowser("https://dash.autossl.com/");
 
         private void QuickStart_Click(object sender, RoutedEventArgs e)
         {

--- a/src/Certify.UI.Shared/Controls/Settings/ManagementHub.xaml
+++ b/src/Certify.UI.Shared/Controls/Settings/ManagementHub.xaml
@@ -13,7 +13,7 @@
     <StackPanel>
 
         <TextBlock Style="{StaticResource Subheading}">Gerencie esta instância usando o Certify Management Hub</TextBlock>
-        <TextBlock Style="{StaticResource Instructions}">Você pode gerenciar centralmente esta instância do Certify Certificate Manager usando o Certify Management Hub. Veja https://certifytheweb.com para mais informações.</TextBlock>
+        <TextBlock Style="{StaticResource Instructions}">Você pode gerenciar centralmente esta instância do Certify Certificate Manager usando o Certify Management Hub. Veja https://autossl.com para mais informações.</TextBlock>
 
         <TextBlock Style="{StaticResource SubheadingWithMargin}" Text="{Binding StatusMessage}" />
 

--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewMode.Design.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewMode.Design.cs
@@ -52,7 +52,7 @@ namespace Certify.UI
                         PreRequestPowerShellScript = @"c:\inetpub\scripts\pre-req-script.ps1",
                         PostRequestPowerShellScript = @"c:\inetpub\scripts\post-req-script.ps1",
                         WebhookTrigger = Webhook.ON_SUCCESS,
-                        WebhookUrl = "https://certifytheweb.com/api/notify?domain=$domain&key=123456",
+                        WebhookUrl = "https://autossl.com/api/notify?domain=$domain&key=123456",
                         WebhookMethod = Webhook.METHOD_POST
                     },
                     CertificatePath = @"C:\ProgramData\ACMESharp\sysVault\99-ASSET\cert_ident1a2b3c4d-all.pfx"

--- a/src/Certify.UI.Shared/Windows/MainWindow.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/MainWindow.xaml.cs
@@ -261,7 +261,7 @@ namespace Certify.UI.Windows
                 }
                 else
                 {
-                    MessageBox.Show("Certify Certificate Manager service not started. Please restart the service. If this problem persists please refer to https://docs.certifytheweb.com/docs/faq and if you cannot resolve the problem contact support@certifytheweb.com.");
+                    MessageBox.Show("Certify Certificate Manager service not started. Please restart the service. If this problem persists please refer to https://docs.autossl.com/faq and if you cannot resolve the problem contact support@autossl.com.");
                 }
 
                 if (_appViewModel.IsFeatureEnabled(FeatureFlags.SERVER_CONNECTIONS))

--- a/src/Certify.UI.Shared/Windows/Registration.xaml
+++ b/src/Certify.UI.Shared/Windows/Registration.xaml
@@ -26,7 +26,7 @@
         <StackPanel DockPanel.Dock="Top" Visibility="{Binding IsRegistrationMode, Converter={StaticResource ResourceKey=BoolToVisConverter}}">
 
             <Grid>
-                <TextBlock Margin="10,10,-10,-11" TextWrapping="WrapWithOverflow"><Run>You can purchase a license key by registering at:</Run><LineBreak /> <Hyperlink NavigateUri="https://certifytheweb.com/register?src=app.enterkey" RequestNavigate="Hyperlink_RequestNavigate">https://certifytheweb.com/register</Hyperlink></TextBlock>
+                <TextBlock Margin="10,10,-10,-11" TextWrapping="WrapWithOverflow"><Run>You can purchase a license key by registering at:</Run><LineBreak /> <Hyperlink NavigateUri="https://autossl.com/register?src=app.enterkey" RequestNavigate="Hyperlink_RequestNavigate">https://autossl.com/register</Hyperlink></TextBlock>
                 <Button
                     x:Name="ValidateKey"
                     Width="112"

--- a/src/Certify.UI.Shared/Windows/Registration.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/Registration.xaml.cs
@@ -95,7 +95,7 @@ namespace Certify.UI.Windows
                 catch (System.Net.Http.HttpRequestException exp)
                 {
                     Log?.Information("ValidateKey:" + exp.ToString());
-                    MessageBox.Show("Communication with the AutoSSL API failed. Check your system can communicate with https://update.autoip.com.br/v1/update using a web browser. \r\n\r\nIf your system is running an older version of Windows, check https://docs.certifytheweb.com for 'TLS Cipher', as updated registry settings may be required.");
+                    MessageBox.Show("Communication with the AutoSSL API failed. Check your system can communicate with https://update.autoip.com.br/v1/update using a web browser. \r\n\r\nIf your system is running an older version of Windows, check https://docs.autossl.com for 'TLS Cipher', as updated registry settings may be required.");
                 }
                 catch (Exception exp)
                 {
@@ -161,7 +161,7 @@ namespace Certify.UI.Windows
                 }
                 else
                 {
-                    MessageBox.Show("The install could not be deactivated, check specified email address is correct for account. You can manually delete the C:\\ProgramData\\Certify\\reg_1 file and deactivate your install on https://certifytheweb.com");
+                    MessageBox.Show("The install could not be deactivated, check specified email address is correct for account. You can manually delete the C:\\ProgramData\\Certify\\reg_1 file and deactivate your install on https://autossl.com");
 
                 }
             }


### PR DESCRIPTION
## Summary
- point documentation URLs to new `docs.autossl.com` domain
- replace old `certifytheweb.com` references with `autossl.com`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68acc59dbc68832e826e3991ea228e8b