### PR TITLE
Rename service to AutoSSL

### DIFF
--- a/src/Certify.Service/Certify.Service.csproj
+++ b/src/Certify.Service/Certify.Service.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>net462</TargetFramework>
         <Configurations>Debug;Release;</Configurations>
-        <AssemblyName>Certify.Service</AssemblyName>
+        <AssemblyName>AutoSSL.Service</AssemblyName>
         <OutputType>Exe</OutputType>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <ApplicationIcon>icon.ico</ApplicationIcon>

--- a/src/Certify.Service/Program.cs
+++ b/src/Certify.Service/Program.cs
@@ -17,8 +17,9 @@ namespace Certify.Service
 
             return (int)HostFactory.Run(x =>
             {
-                x.SetDisplayName("Certify Certificate Manager Service");
-                x.SetDescription("Certify Certificate Manager Service");
+                x.SetDisplayName("AutoSSL Service");
+                x.SetDescription("AutoSSL Service");
+                x.SetServiceName("AutoSSL.Service");
                 x.StartAutomaticallyDelayed();
 
                 x.OnException(ex =>


### PR DESCRIPTION
## Summary
- rename service display and description to AutoSSL
- set service name and executable to AutoSSL.Service

## Testing
- `dotnet test src/Certify.Core.Service.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68acd4089ffc832ebdef3da9bdcd0cd8