### PR TITLE
feat(appdata): add env override for app data folder

### DIFF
--- a/src/Certify.Models/Shared/SharedConstants.cs
+++ b/src/Certify.Models/Shared/SharedConstants.cs
@@ -3,9 +3,9 @@
     public static class SharedConstants
     {
 #if _DEMO_
-        public const string APPDATASUBFOLDER = "CertifyDemo";
+        public const string APPDATASUBFOLDER = "AutoSSLDemo";
 #else
-        public const string APPDATASUBFOLDER = "certify";
+        public const string APPDATASUBFOLDER = "AutoSSL";
 #endif
     }
 }

--- a/src/Certify.Shared/Utils/Util.cs
+++ b/src/Certify.Shared/Utils/Util.cs
@@ -309,10 +309,15 @@ namespace Certify.Management
 
         public static string GetUserLocalAppDataFolder()
         {
-            var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Models.SharedConstants.APPDATASUBFOLDER);
-            if (!System.IO.Directory.Exists(path))
+            // allow override via CERTIFY_APPDATA_PATH environment variable
+            var envPath = Environment.GetEnvironmentVariable("CERTIFY_APPDATA_PATH");
+            var path = !string.IsNullOrEmpty(envPath)
+                ? envPath
+                : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Models.SharedConstants.APPDATASUBFOLDER);
+
+            if (!Directory.Exists(path))
             {
-                System.IO.Directory.CreateDirectory(path);
+                Directory.CreateDirectory(path);
             }
 
             return path;


### PR DESCRIPTION
## Summary
- rename app data subfolder to AutoSSL
- allow CERTIFY_APPDATA_PATH to override user app data location

## Testing
- `dotnet test src/Certify.Tests/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*
- `ls -ld /usr/local/share/AutoSSL`
- `su testuser -c 'mkdir /usr/local/share/AutoSSL/test'` *(fails: permission denied)*
- `su testuser -c 'CERTIFY_APPDATA_PATH=/tmp/autossl; mkdir -p "$CERTIFY_APPDATA_PATH"; touch "$CERTIFY_APPDATA_PATH/test"; ls -ld "$CERTIFY_APPDATA_PATH"'`


------
https://chatgpt.com/codex/tasks/task_e_68acd498378c832e912219eedaeeb22d