### PR TITLE
Add installer scripts for AutoSSL

### DIFF
--- a/scripts/installers/AutoSSLInstaller.iss
+++ b/scripts/installers/AutoSSLInstaller.iss
@@ -1,0 +1,44 @@
+; AutoSSL installer script for Inno Setup
+[Setup]
+AppName=AutoSSL
+AppVersion=1.0
+DefaultDirName={pf}\\AutoSSL
+DefaultGroupName=AutoSSL
+DisableProgramGroupPage=yes
+OutputDir=.
+OutputBaseFilename=AutoSSLSetup
+
+[Files]
+Source: "..\\..\\bin\\*"; DestDir: "{app}"; Flags: recursesubdirs
+
+[Dirs]
+Name: "{commonappdata}\\AutoSSL";
+Name: "{commonappdata}\\AutoSSL\\logs";
+Name: "{commonappdata}\\AutoSSL\\config";
+Name: "{commonappdata}\\AutoSSL\\plugins";
+
+[Run]
+; Install and start the Windows service
+Filename: "{app}\\AutoSSL.Service.exe"; Parameters: "install"; Flags: runhidden
+Filename: "sc.exe"; Parameters: "start AutoSSL.Service"; Flags: runhidden
+
+[UninstallRun]
+; Stop and delete the Windows service during uninstall
+Filename: "sc.exe"; Parameters: "stop AutoSSL.Service"; Flags: runhidden
+Filename: "sc.exe"; Parameters: "delete AutoSSL.Service"; Flags: runhidden
+
+[Icons]
+Name: "{group}\\AutoSSL UI"; Filename: "{app}\\AutoSSL.UI.exe"
+Name: "{group}\\AutoSSL Update"; Filename: "{app}\\update.bat"
+Name: "{commondesktop}\\AutoSSL UI"; Filename: "{app}\\AutoSSL.UI.exe"; Tasks: desktopicon
+
+[Tasks]
+Name: desktopicon; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Code]
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usPostUninstall then
+    if MsgBox('Deseja remover dados em {commonappdata}\\AutoSSL?', mbConfirmation, MB_YESNO) = idYes then
+      DelTree(ExpandConstant('{commonappdata}\\AutoSSL'), True, True, True);
+end;

--- a/scripts/installers/AutoSSLInstaller.nsi
+++ b/scripts/installers/AutoSSLInstaller.nsi
@@ -1,0 +1,44 @@
+; AutoSSL installer script for NSIS
+!include "MUI2.nsh"
+
+Name "AutoSSL"
+OutFile "AutoSSLSetup.exe"
+InstallDir "$PROGRAMFILES\AutoSSL"
+RequestExecutionLevel admin
+
+Page directory
+Page instfiles
+
+UninstPage uninstConfirm
+UninstPage instfiles
+
+Section "Install"
+  SetOutPath "$INSTDIR"
+  File /r "..\..\bin\*"
+
+  CreateDirectory "$PROGRAMDATA\AutoSSL"
+  CreateDirectory "$PROGRAMDATA\AutoSSL\logs"
+  CreateDirectory "$PROGRAMDATA\AutoSSL\config"
+  CreateDirectory "$PROGRAMDATA\AutoSSL\plugins"
+
+  nsExec::Exec '"$INSTDIR\AutoSSL.Service.exe" install'
+  nsExec::Exec 'sc start AutoSSL.Service'
+
+  CreateShortCut "$SMPROGRAMS\AutoSSL\AutoSSL UI.lnk" "$INSTDIR\AutoSSL.UI.exe"
+  CreateShortCut "$SMPROGRAMS\AutoSSL\AutoSSL Update.lnk" "$INSTDIR\update.bat"
+SectionEnd
+
+Section "Uninstall"
+  nsExec::Exec 'sc stop AutoSSL.Service'
+  nsExec::Exec 'sc delete AutoSSL.Service'
+
+  Delete "$SMPROGRAMS\AutoSSL\AutoSSL UI.lnk"
+  Delete "$SMPROGRAMS\AutoSSL\AutoSSL Update.lnk"
+  RMDir "$SMPROGRAMS\AutoSSL"
+
+  Delete "$INSTDIR\*.*"
+  RMDir "$INSTDIR"
+
+  MessageBox MB_YESNO "Deseja remover dados em $PROGRAMDATA\AutoSSL?" IDNO +2
+    RMDir /r "$PROGRAMDATA\AutoSSL"
+SectionEnd


### PR DESCRIPTION
## Summary
- add Inno Setup script to install AutoSSL binaries and service
- add NSIS script with equivalent installation and service handling

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68acda4e9b74832eb72c83353a1c04d7