### PR TITLE
refactor: remove licensing and telemetry checks

### DIFF
--- a/src/Certify.Models/Providers/Internal/DashboardClient.cs
+++ b/src/Certify.Models/Providers/Internal/DashboardClient.cs
@@ -1,124 +1,25 @@
-﻿using System;
-using System.Diagnostics;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Certify.Models.Plugins;
 using Certify.Models.Shared;
-using Newtonsoft.Json;
 
 namespace Certify.Providers.Internal
 {
+    /// <summary>
+    /// Stubbed dashboard client. All methods succeed without performing any
+    /// network communication.
+    /// </summary>
     public class DashboardClient : IDashboardClient
     {
-        private readonly HttpClient _client;
+        public Task<bool> SubmitFeedbackAsync(FeedbackReport feedback, string frameworkVersion) => Task.FromResult(true);
 
-        public DashboardClient()
-        {
-            _client = new HttpClient();
-        }
+        public Task<bool> ReportRenewalStatusAsync(RenewalStatusReport report) => Task.FromResult(true);
 
-        private async Task<HttpResponseMessage> PostAsync(string endpoint, object data)
-        {
-            var _baseURI = Models.API.Config.APIBaseURI;
+        public Task<bool> ReportServerStatusAsync() => Task.FromResult(true);
 
-            if (data != null)
-            {
-                var json = JsonConvert.SerializeObject(data);
-                var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+        public Task<bool> SignInAsync(string email, string pwd) => Task.FromResult(true);
 
-                return await _client.PostAsync(_baseURI + endpoint, content);
-            }
-            else
-            {
-                return await _client.PostAsync(_baseURI + endpoint, new StringContent(""));
-            }
-        }
+        public Task<bool> RegisterInstance(RegisteredInstance instance, string email, string pwd, bool createAccount) => Task.FromResult(true);
 
-        public async Task<bool> ReportRenewalStatusAsync(RenewalStatusReport report)
-        {
-            try
-            {
-                var response = await PostAsync("status/submit", report);
-                return response.IsSuccessStatusCode;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
-        public async Task<bool> ReportUserActionRequiredAsync(ItemActionRequired actionRequired)
-        {
-            try
-            {
-                var response = await PostAsync("status/actionRequired", actionRequired);
-
-                Debug.WriteLine(JsonConvert.SerializeObject(response));
-                return true;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
-
-        public Task<bool> ReportServerStatusAsync()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<bool> SignInAsync(string email, string pwd)
-        {
-            throw new NotImplementedException();
-        }
-
-        public async Task<bool> SubmitFeedbackAsync(FeedbackReport feedback, string frameworkVersion)
-        {
-            //submit feedback if connection available
-
-            feedback.SupportingData = new
-            {
-                Framework = frameworkVersion,
-                OS = Environment.OSVersion.ToString(),
-                feedback.IsException,
-                feedback.AppVersion
-            };
-
-            try
-            {
-                var response = await PostAsync("feedback/submit", feedback);
-                if (response.IsSuccessStatusCode)
-                {
-                    return true;
-                }
-            }
-            catch (Exception exp)
-            {
-                Debug.WriteLine(exp.ToString());
-            }
-
-            return false;
-        }
-
-        public async Task<bool> RegisterInstance(RegisteredInstance instance, string email, string pwd, bool createAccount)
-        {
-            try
-            {
-                //_baseUri = "http://localhost:57248/v1/";
-                var response = await PostAsync("status/register", new
-                {
-                    Instance = instance,
-                    Email = email,
-                    Password = pwd,
-                    CreateAccount = createAccount
-                });
-
-                return response.IsSuccessStatusCode;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
+        public Task<bool> ReportUserActionRequiredAsync(ItemActionRequired actionRequired) => Task.FromResult(true);
     }
 }

--- a/src/Certify.Models/Providers/Internal/LicenseManager.cs
+++ b/src/Certify.Models/Providers/Internal/LicenseManager.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
@@ -302,66 +301,15 @@ namespace Certify.Providers.Internal
 
         public async Task<LicenseCheckResult> Validate(int productTypeId, string email, string key)
         {
-            Log("----------------");
-            Log("Validating key:" + key);
-            Log("Validating email:" + email);
-            using (var client = new HttpClient())
+            // External license validation has been disabled. Always return a
+            // successful validation result without performing any HTTP
+            // requests.
+            return await Task.FromResult(new LicenseCheckResult
             {
-                Log("Created HttpClient");
-                SetSupportedTLSVersions(_enableLog);
-                Log("Set TLS");
-
-                var jsonRequest = JsonConvert.SerializeObject(
-                    new
-                    {
-                        ProductTypeId = productTypeId,
-                        Email = email,
-                        Key = key
-                    });
-
-                Log("Data: " + JsonConvert.SerializeObject(jsonRequest));
-
-                var data = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-
-                var url = Models.API.Config.APIBaseURI + "license/validate";
-
-                Log($"Posting to: {url}");
-
-                try
-                {
-                    var response = await client.PostAsync(url, data);
-
-                    if (response.IsSuccessStatusCode)
-                    {
-                        var jsonResult = await response.Content.ReadAsStringAsync();
-
-                        Log($"Received: {response.ToString()}");
-                        Log($"Received result: {jsonResult}");
-                        //validate given license key has not expired
-
-                        try
-                        {
-                            var result = JsonConvert.DeserializeObject<LicenseCheckResult>(jsonResult);
-                            return result;
-                        }
-                        catch (Exception ex)
-                        {
-                            Log($"Failed to deserialize: {ex}");
-                            throw;
-                        }
-                    }
-                    else
-                    {
-                        Log($"submission failed: {response}");
-                        return new LicenseCheckResult { IsValid = false, StatusCode = "OFFLINE", ValidationMessage = "There was a problem validating this key. Please ensure you have the latest app version and try again later." };
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log($"Post to API failed: {ex}");
-                    throw;
-                }
-            }
+                IsValid = true,
+                StatusCode = "VALID",
+                ValidationMessage = "License validation disabled"
+            });
         }
 
         public static void SetSupportedTLSVersions(bool enableLog)
@@ -389,82 +337,23 @@ namespace Certify.Providers.Internal
 
         public async Task<LicenseKeyInstallResult> RegisterInstall(int productTypeId, string email, string key, RegisteredInstance instance)
         {
-            Log("Registering Install based on key:" + key);
-
-            instance.MachineName = Environment.MachineName;
-            instance.OS = Environment.OSVersion.ToString();
-
-            using (var client = new HttpClient())
+            // Registration normally contacts the licensing server. For the open
+            // source build we simply return a successful result and do not
+            // perform any remote calls.
+            return await Task.FromResult(new LicenseKeyInstallResult
             {
-
-                SetSupportedTLSVersions(_enableLog);
-
-                var jsonRequest = JsonConvert.SerializeObject(
-                    new
-                    {
-                        ProductTypeId = productTypeId,
-                        Email = email,
-                        Key = key,
-                        Instance = instance
-                    });
-
-                Log("Instance: " + JsonConvert.SerializeObject(jsonRequest));
-
-                var data = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-                var response = await client.PostAsync(Models.API.Config.APIBaseURI + "license/install", data);
-                if (response.IsSuccessStatusCode)
-                {
-                    var jsonResult = await response.Content.ReadAsStringAsync();
-
-                    Log("Install Response: " + JsonConvert.SerializeObject(jsonRequest));
-                    //validate given license key has not expired
-                    var result = JsonConvert.DeserializeObject<LicenseKeyInstallResult>(jsonResult);
-
-                    return result;
-                }
-                else
-                {
-                    Log("Install Response Failed: " + JsonConvert.SerializeObject(response.ToString()));
-                    return new LicenseKeyInstallResult { IsSuccess = false, Message = "There was a problem validating this key. Please ensure you have the latest app version and try again later." };
-                }
-            }
+                IsSuccess = true,
+                Message = "License activation disabled",
+                UsageToken = Guid.NewGuid().ToString()
+            });
         }
 
         public async Task<bool> DeactivateInstall(int productTypeId, string settingsPath, string email, RegisteredInstance instance)
         {
-            Log("Deactivating Install");
-            var install = GetLicenseKeyInstallResult(productTypeId, settingsPath);
-            if (install != null)
-            {
-                instance.MachineName = Environment.MachineName;
-                instance.OS = Environment.OSVersion.ToString();
-
-                using (var client = new HttpClient())
-                {
-
-                    SetSupportedTLSVersions(_enableLog);
-
-                    var jsonRequest = JsonConvert.SerializeObject(
-                        new
-                        {
-                            ProductTypeId = productTypeId,
-                            Email = email,
-                            install.UsageToken,
-                            Instance = instance
-                        });
-
-                    var data = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-                    var response = await client.PostAsync(Models.API.Config.APIBaseURI + "license/uninstall", data);
-                    if (response.IsSuccessStatusCode)
-                    {
-                        DeleteLicenseKeyInstall(productTypeId, settingsPath);
-                        return true;
-                    }
-                }
-            }
-
-            Log("Deactivating Install Failed");
-            return false;
+            // Deactivation no longer contacts external services. Always succeed
+            // and remove any stored license data if present.
+            DeleteLicenseKeyInstall(productTypeId, settingsPath);
+            return await Task.FromResult(true);
         }
 
         public bool FinaliseInstall(int productTypeId, LicenseKeyInstallResult result, string settingsPath)
@@ -562,15 +451,8 @@ namespace Certify.Providers.Internal
 
         public bool IsInstallRegistered(int productTypeId, string settingsPath)
         {
-            var result = GetLicenseKeyInstallResult(productTypeId, settingsPath);
-            if (result?.IsSuccess == true)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            // Licensing is disabled so every install is treated as registered.
+            return true;
         }
 
         public DateTime? GetInstallDate(string settingsPath)
@@ -586,42 +468,9 @@ namespace Certify.Providers.Internal
 
         public async Task<bool> IsInstallActive(int productTypeId, string settingsPath)
         {
-
-            var result = GetLicenseKeyInstallResult(productTypeId, settingsPath);
-            if (result != null)
-            {
-
-                try
-                {
-                    var id = result.UsageToken;
-
-                    using (var client = new HttpClient())
-                    {
-
-                        SetSupportedTLSVersions(_enableLog);
-
-                        var response = await client.GetAsync(Models.API.Config.APIBaseURI + "license/check?id=" + id);
-                        if (response.IsSuccessStatusCode)
-                        {
-                            return JsonConvert.DeserializeObject<bool>(await response.Content.ReadAsStringAsync());
-                        }
-                        else
-                        {
-                            //default to true if request fails
-                            return true;
-                        }
-                    }
-                }
-                catch (Exception)
-                {
-                    // failed to query status
-                    return true;
-                }
-            }
-            else
-            {
-                return false;
-            }
+            // Always consider the install active. No network checks are
+            // performed.
+            return await Task.FromResult(true);
         }
 
         public LicenseCheckResult GetCurrentLicense(int productTypeId, string settingsPath)

--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Settings.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Settings.cs
@@ -105,19 +105,9 @@ namespace Certify.UI.ViewModel
         /// <returns></returns>
         public bool IsFeatureEnabled(string featureFlag)
         {
-            if (StandardFeatures.Any(f => f == featureFlag))
-            {
-                return true;
-            }
-
-            if (Preferences?.FeatureFlags?.Contains(featureFlag) == true)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            // All features are always enabled. Original feature flag checks and
+            // license gating have been removed.
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- disable license validation and activation network calls
- stub dashboard client to prevent external telemetry
- enable all feature flags by default

## Testing
- `dotnet test src/Certify.Core.Service.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace4a4b4a0832e8f7e0983fa5d4fb0