### PR TITLE
chore(ui): traduzir diálogo de conexão do repositório de dados

### DIFF
--- a/src/Certify.UI.Shared/Windows/EditDataStoreConnection.xaml
+++ b/src/Certify.UI.Shared/Windows/EditDataStoreConnection.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
-    Title="Edit Data Store Connection"
+    Title="Editar conexão do repositório de dados"
     Width="522"
     Height="276"
     Background="{DynamicResource MahApps.Brushes.Window.Background}"
@@ -30,7 +30,7 @@
             VerticalAlignment="Top"
             DockPanel.Dock="Top"
             Style="{StaticResource Instructions}"
-            TextWrapping="Wrap"><Run Text="Before adding a data store you must create or restore a compatible database schema on the database server. See the documentation site for more details." /><LineBreak /><Run /></TextBlock>
+            TextWrapping="Wrap"><Run Text="Antes de adicionar um repositório de dados, é necessário criar ou restaurar um esquema de banco de dados compatível no servidor de banco de dados. Consulte o site da documentação para mais detalhes." /><LineBreak /><Run /></TextBlock>
         <StackPanel
             Margin="0,0,0,8"
             DockPanel.Dock="Top"
@@ -38,13 +38,13 @@
             <Label
                 Width="120"
                 Margin="0,0,8,0"
-                Content="Title" />
+                Content="Título" />
             <TextBox
                 Width="300"
                 Height="23"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
-                Controls:TextBoxHelper.Watermark="e.g. A display name, e.g. SQL Server on SRV01 etc "
+                Controls:TextBoxHelper.Watermark="ex.: um nome de exibição, como SQL Server no SRV01 etc"
                 Text="{Binding Item.Title}"
                 TextWrapping="Wrap" />
         </StackPanel>
@@ -57,7 +57,7 @@
                 Margin="0,0,8,0"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
-                Content="Data Store Type" />
+                Content="Tipo de repositório de dados" />
             <ComboBox
                 x:Name="ProviderTypes"
                 MinWidth="200"
@@ -75,13 +75,13 @@
             <Label
                 Width="120"
                 Margin="0,0,8,0"
-                Content="Connection String" />
+                Content="Cadeia de conexão" />
             <TextBox
                 Width="300"
                 Height="42"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
-                Controls:TextBoxHelper.Watermark="e.g. a database connection string"
+                Controls:TextBoxHelper.Watermark="ex.: uma cadeia de conexão de banco de dados"
                 Text="{Binding Item.ConnectionConfig}"
                 TextWrapping="Wrap"
                 VerticalScrollBarVisibility="Auto" />


### PR DESCRIPTION
## Summary
- traduzir título, instruções e rótulos do diálogo de conexão de repositório de dados

## Testing
- `dotnet build src/Certify.UI.sln` *(falhou: comando não encontrado)*
- `apt-get update` *(falhou: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acf8f6d200832eb105de63b6773f31