### PR TITLE
Track completed request history and refine progress state

### DIFF
--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.ManagedCertificates.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.ManagedCertificates.cs
@@ -264,12 +264,17 @@ namespace Certify.UI.ViewModel
         /// If true, one or more requests are currently in progress
         /// </summary>
         [DependsOn(nameof(ProgressResults))]
-        public bool HasRequestsInProgress => (ProgressResults != null && ProgressResults.Any());
+        public bool HasRequestsInProgress => ProgressResults?.Any(p => p.IsRunning) ?? false;
 
         /// <summary>
         /// Cached list of current request operations in progress
         /// </summary>
         public ObservableCollection<RequestProgressState> ProgressResults { get; set; }
+
+        /// <summary>
+        /// History of completed request operations
+        /// </summary>
+        public ObservableCollection<RequestProgressState> ProgressResultsHistory { get; set; }
 
         /// <summary>
         /// Begin tracking progress info for a given managed certificate
@@ -409,6 +414,16 @@ namespace Certify.UI.ViewModel
                     ProgressResults.Add(state);
                 }
 
+                if (state.CurrentState == RequestState.Success ||
+                    state.CurrentState == RequestState.Error ||
+                    state.CurrentState == RequestState.Warning ||
+                    state.CurrentState == RequestState.Skipped)
+                {
+                    ProgressResults.Remove(state);
+                    ProgressResultsHistory.Add(state);
+                    RaisePropertyChangedEvent(nameof(ProgressResultsHistory));
+                }
+
                 RaisePropertyChangedEvent(nameof(HasRequestsInProgress));
                 RaisePropertyChangedEvent(nameof(ProgressResults));
             });
@@ -420,8 +435,10 @@ namespace Certify.UI.ViewModel
         public void ClearRequestProgressResults()
         {
             ProgressResults = new ObservableCollection<RequestProgressState>();
+            ProgressResultsHistory = new ObservableCollection<RequestProgressState>();
             RaisePropertyChangedEvent(nameof(HasRequestsInProgress));
             RaisePropertyChangedEvent(nameof(ProgressResults));
+            RaisePropertyChangedEvent(nameof(ProgressResultsHistory));
         }
 
         /// <summary>

--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.cs
@@ -77,6 +77,7 @@ namespace Certify.UI.ViewModel
             Log = new Loggy(new Serilog.Extensions.Logging.SerilogLoggerFactory(serilogLog).CreateLogger<AppViewModel>());
 
             ProgressResults = new ObservableCollection<RequestProgressState>();
+            ProgressResultsHistory = new ObservableCollection<RequestProgressState>();
 
             ImportedManagedCertificates = new ObservableCollection<ManagedCertificate>();
             ManagedCertificates = new ObservableCollection<ManagedCertificate>();


### PR DESCRIPTION
## Summary
- track completed certificate requests in a new ProgressResultsHistory collection
- remove finished requests from current progress and adjust in-progress indicator
- initialize and reset progress history alongside existing progress tracking

## Testing
- `dotnet build src/Certify.UI.Shared/Certify.UI.Shared.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1b39dd5c832e91d109cbbb98e752