### PR TITLE
Refresh managed certificates after successful requests

### DIFF
--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.ManagedCertificates.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.ManagedCertificates.cs
@@ -357,6 +357,8 @@ namespace Certify.UI.ViewModel
                     SelectedItem = newItem;
                 }
 
+                newItem?.RaisePropertyChangedEvent(nameof(ManagedCertificate.CertificateLifetime));
+
                 RaisePropertyChangedEvent(nameof(ManagedCertificates));
 
                 return newItem;
@@ -422,6 +424,11 @@ namespace Certify.UI.ViewModel
                     ProgressResults.Remove(state);
                     ProgressResultsHistory.Add(state);
                     RaisePropertyChangedEvent(nameof(ProgressResultsHistory));
+
+                    if (state.CurrentState == RequestState.Success)
+                    {
+                        _ = RefreshManagedCertificates();
+                    }
                 }
 
                 RaisePropertyChangedEvent(nameof(HasRequestsInProgress));


### PR DESCRIPTION
## Summary
- refresh local managed certificate list when a request completes successfully
- ensure cache updates trigger `CertificateLifetime` recalculation

## Testing
- `dotnet test src/Certify.Core.Tests.Unit/Certify.Core.Tests.Unit.csproj` *(fails: bash: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1c8dfe04832ea143b63175752748