### PR TITLE
chore(localization): translate connection dialog examples

### DIFF
--- a/src/Certify.UI.Shared/Windows/EditServerConnection.xaml
+++ b/src/Certify.UI.Shared/Windows/EditServerConnection.xaml
@@ -47,7 +47,7 @@
                 Height="23"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
-                Controls:TextBoxHelper.Watermark="e.g. Primary Server, WEB01 etc "
+                Controls:TextBoxHelper.Watermark="ex.: Servidor Primário, WEB01 etc "
                 Text="{Binding Item.DisplayName}"
                 TextWrapping="Wrap" />
         </StackPanel>
@@ -81,7 +81,7 @@
                 Height="23"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Top"
-                Controls:TextBoxHelper.Watermark="e.g. 9696"
+                Controls:TextBoxHelper.Watermark="ex.: 9696"
                 Text="{Binding Item.Port}"
                 TextWrapping="Wrap" />
         </StackPanel>

--- a/src/Certify.UI.Shared/Windows/EditServerConnection.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/EditServerConnection.xaml.cs
@@ -56,7 +56,7 @@ namespace Certify.UI.Windows
             }
             else
             {
-                MessageBox.Show("Failed to save connection details.");
+                MessageBox.Show("Falha ao salvar os detalhes da conexão.");
             }
         }
     }


### PR DESCRIPTION
## Summary
- localize example watermarks for server connection editor fields
- translate save-error notification in connection dialog

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68adde994a00832eb39aa61013a346c5