### PR TITLE
feat: translate dashboard registration messages

### DIFF
--- a/src/Certify.UI.Shared/Windows/AddToDashboard.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/AddToDashboard.xaml.cs
@@ -61,12 +61,12 @@ namespace Certify.UI.Windows
                     if (resultOK)
                     {
                         await ViewModel.AppViewModel.Current.SetInstanceRegisteredOnDashboard();
-                        MessageBox.Show("Server registration completed.");
+                        MessageBox.Show("Registro do servidor concluído.");
                         Close();
                     }
                     else
                     {
-                        MessageBox.Show("Server registration could not complete. Check your username and password is correct and that outgoing https connections are allowed from this machine.");
+                        MessageBox.Show("O registro do servidor não pôde ser concluído. Verifique se seu nome de usuário e senha estão corretos e se conexões HTTPS de saída são permitidas nesta máquina.");
                     }
                 }
                 catch (Exception)


### PR DESCRIPTION
## Summary
- translate server registration success and failure messages to Brazilian Portuguese

## Testing
- `dotnet build src/Certify.UI.Shared/Certify.UI.Shared.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68addea154cc832e96d924f52bf3fae8