### PR TITLE
Localize data store connection prompts

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -383,7 +383,79 @@ namespace Certify.Locales {
                 return ResourceManager.GetString("Dashboard_Warnings", resourceCulture);
             }
         }
-       
+
+        /// <summary>
+        ///   Looks up a localized string similar to This is the current data store connection.
+        /// </summary>
+        public static string DataStoreConnections_CurrentConnection {
+            get {
+                return ResourceManager.GetString("DataStoreConnections_CurrentConnection", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Connect to Data Store.
+        /// </summary>
+        public static string DataStoreConnections_ConnectTitle {
+            get {
+                return ResourceManager.GetString("DataStoreConnections_ConnectTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Switch primary data store for service to {0}?.
+        /// </summary>
+        public static string DataStoreConnections_SwitchPrompt {
+            get {
+                return ResourceManager.GetString("DataStoreConnections_SwitchPrompt", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Switch Data Store.
+        /// </summary>
+        public static string DataStoreConnections_SwitchTitle {
+            get {
+                return ResourceManager.GetString("DataStoreConnections_SwitchTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The source and target data source selections are required.
+        /// </summary>
+        public static string DataStoreConnections_SourceTargetRequired {
+            get {
+                return ResourceManager.GetString("DataStoreConnections_SourceTargetRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The source and target data source cannot be the same.
+        /// </summary>
+        public static string DataStoreConnections_SourceTargetSame {
+            get {
+                return ResourceManager.GetString("DataStoreConnections_SourceTargetSame", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Copy data from {0} to {1}? Existing items in the target will be overwritten.
+        /// </summary>
+        public static string DataStoreConnections_CopyPrompt {
+            get {
+                return ResourceManager.GetString("DataStoreConnections_CopyPrompt", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Copy Data.
+        /// </summary>
+        public static string DataStoreConnections_CopyTitle {
+            get {
+                return ResourceManager.GetString("DataStoreConnections_CopyTitle", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Delete.
         /// </summary>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -723,6 +723,30 @@
   <data name="Dashboard_NoCertificate" xml:space="preserve">
     <value>Sem Certificado</value>
   </data>
+  <data name="DataStoreConnections_CurrentConnection" xml:space="preserve">
+    <value>This is the current data store connection.</value>
+  </data>
+  <data name="DataStoreConnections_ConnectTitle" xml:space="preserve">
+    <value>Connect to Data Store</value>
+  </data>
+  <data name="DataStoreConnections_SwitchPrompt" xml:space="preserve">
+    <value>Switch primary data store for service to {0}?</value>
+  </data>
+  <data name="DataStoreConnections_SwitchTitle" xml:space="preserve">
+    <value>Switch Data Store</value>
+  </data>
+  <data name="DataStoreConnections_SourceTargetRequired" xml:space="preserve">
+    <value>The source and target data source selections are required.</value>
+  </data>
+  <data name="DataStoreConnections_SourceTargetSame" xml:space="preserve">
+    <value>The source and target data source cannot be the same.</value>
+  </data>
+  <data name="DataStoreConnections_CopyPrompt" xml:space="preserve">
+    <value>Copy data from {0} to {1}? Existing items in the target will be overwritten.</value>
+  </data>
+  <data name="DataStoreConnections_CopyTitle" xml:space="preserve">
+    <value>Copy Data</value>
+  </data>
   <data name="Preview_Title" xml:space="preserve">
     <value>Pré-visualização</value>
   </data>

--- a/src/Certify.UI.Shared/Windows/DataStoreConnections.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/DataStoreConnections.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
+using Certify.Locales;
 using Certify.Models;
 using Certify.Shared;
 using Certify.UI.ViewModel;
@@ -72,11 +73,11 @@ namespace Certify.UI.Windows
 
             if (selectedConnection?.Id == AppViewModel.Current.Preferences.ConfigDataStoreConnectionId)
             {
-                MessageBox.Show("This is the current data store connection.", "Connect to Data Store");
+                MessageBox.Show(SR.DataStoreConnections_CurrentConnection, SR.DataStoreConnections_ConnectTitle);
                 return;
             }
 
-            if (MessageBox.Show($"Switch primary data store for service to {selectedConnection.Title}?", "Switch Data Store", MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
+            if (MessageBox.Show(string.Format(SR.DataStoreConnections_SwitchPrompt, selectedConnection.Title), SR.DataStoreConnections_SwitchTitle, MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
             {
                 //TODO: perform data store connection and schema check before switching
                 var results = await ViewModel.AppViewModel.Current.SetDefaultDataStore(selectedConnection.Id, _cts.Token);
@@ -109,20 +110,20 @@ namespace Certify.UI.Windows
 
             if (string.IsNullOrEmpty(sourceId) || string.IsNullOrEmpty(targetId))
             {
-                AppViewModel.Current.ShowNotification("The source and target data source selections are required.", Shared.NotificationType.Error);
+                AppViewModel.Current.ShowNotification(SR.DataStoreConnections_SourceTargetRequired, Shared.NotificationType.Error);
                 return;
             }
 
             if (sourceId == targetId)
             {
-                AppViewModel.Current.ShowNotification("The source and target data source cannot be the same.", Shared.NotificationType.Error);
+                AppViewModel.Current.ShowNotification(SR.DataStoreConnections_SourceTargetSame, Shared.NotificationType.Error);
                 return;
             }
 
             var source = _model.Connections.FirstOrDefault(c => c.Id == sourceId);
             var target = _model.Connections.FirstOrDefault(c => c.Id == targetId);
 
-            if (MessageBox.Show($"Copy data from {source?.Title} to {target?.Title}? Existing items in the target will be overwritten.", "Copy Data", MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
+            if (MessageBox.Show(string.Format(SR.DataStoreConnections_CopyPrompt, source?.Title, target?.Title), SR.DataStoreConnections_CopyTitle, MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
             {
                 _model.IsLoading = true;
 


### PR DESCRIPTION
## Summary
- localize connect and switch messages for data store connections
- add resource strings for data store selection validation and copy prompts

## Testing
- `dotnet build src/Certify.UI.Shared/Certify.UI.Shared.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adde9f4e7c832eafb4e9b0d5351bb1