### PR TITLE
Localize registration messaging

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -1701,6 +1701,69 @@ namespace Certify.Locales {
                 return ResourceManager.GetString("Registration_UnableToVerify", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Communication with the AutoSSL API failed. Check your system can communicate with https://update.autoip.com.br/v1/update using a web browser. If your system is running an older version of Windows, check https://docs.certifytheweb.com for 'TLS Cipher', as updated registry settings may be required.
+        /// </summary>
+        public static string Registration_ApiCommunicationFailed {
+            get {
+                return ResourceManager.GetString("Registration_ApiCommunicationFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The install could not be deactivated, check specified email address is correct for account. You can manually delete the C:\ProgramData\Certify\reg_1 file and deactivate your install on https://certifytheweb.com.
+        /// </summary>
+        public static string Registration_DeactivateFailed {
+            get {
+                return ResourceManager.GetString("Registration_DeactivateFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Deactivate Install.
+        /// </summary>
+        public static string Registration_DeactivateInstall {
+            get {
+                return ResourceManager.GetString("Registration_DeactivateInstall", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This install has now been deactivated. You can enter a different license key or use your key on another install.
+        /// </summary>
+        public static string Registration_DeactivateSuccess {
+            get {
+                return ResourceManager.GetString("Registration_DeactivateSuccess", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Your installation is currently using a license key. If you wish to change license key or allocate this license to a different install you can deactivate the license for this install:.
+        /// </summary>
+        public static string Registration_DeactivationIntro {
+            get {
+                return ResourceManager.GetString("Registration_DeactivationIntro", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You can purchase a license key by registering at:.
+        /// </summary>
+        public static string Registration_LicensePurchaseInstruction {
+            get {
+                return ResourceManager.GetString("Registration_LicensePurchaseInstruction", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not load the licensing validation plugin. The app may need to be re-installed.
+        /// </summary>
+        public static string Registration_PluginLoadFailed {
+            get {
+                return ResourceManager.GetString("Registration_PluginLoadFailed", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Registered Email Address.

--- a/src/Certify.Locales/SR.es-ES.resx
+++ b/src/Certify.Locales/SR.es-ES.resx
@@ -231,6 +231,27 @@
   <data name="Registration_UnableToVerify" xml:space="preserve">
     <value>Hubo un problema al comenzar el proceso de validación de la licencia.</value>
   </data>
+  <data name="Registration_LicensePurchaseInstruction" xml:space="preserve">
+    <value>Puede comprar una clave de licencia registrándose en:</value>
+  </data>
+  <data name="Registration_DeactivationIntro" xml:space="preserve">
+    <value>Su instalación está utilizando actualmente una clave de licencia. Si desea cambiar la clave o asignar esta licencia a otra instalación, puede desactivar la licencia para esta instalación:</value>
+  </data>
+  <data name="Registration_DeactivateInstall" xml:space="preserve">
+    <value>Desactivar instalación</value>
+  </data>
+  <data name="Registration_ApiCommunicationFailed" xml:space="preserve">
+    <value>La comunicación con la API de AutoSSL falló. Compruebe que su sistema puede comunicarse con https://update.autoip.com.br/v1/update mediante un navegador web.&#x0a;&#x0a;Si su sistema ejecuta una versión antigua de Windows, consulte https://docs.certifytheweb.com sobre 'TLS Cipher', ya que podrían requerirse configuraciones de registro actualizadas.</value>
+  </data>
+  <data name="Registration_PluginLoadFailed" xml:space="preserve">
+    <value>No se pudo cargar el complemento de validación de licencias. Es posible que deba reinstalar la aplicación.</value>
+  </data>
+  <data name="Registration_DeactivateSuccess" xml:space="preserve">
+    <value>Esta instalación ha sido desactivada. Puede introducir una clave de licencia diferente o usar su clave en otra instalación.</value>
+  </data>
+  <data name="Registration_DeactivateFailed" xml:space="preserve">
+    <value>No se pudo desactivar la instalación; verifique que la dirección de correo especificada sea correcta para la cuenta. Puede eliminar manualmente el archivo C:\ProgramData\Certify\reg_1 y desactivar su instalación en https://certifytheweb.com</value>
+  </data>
   <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
     <value>La tarea de renovación automática ya está configurada. Si es necesario, puede cambiar la cuenta de usuario de administrador utilizada para ejecutar la tarea.</value>
   </data>

--- a/src/Certify.Locales/SR.ja-JP.resx
+++ b/src/Certify.Locales/SR.ja-JP.resx
@@ -219,6 +219,27 @@
   <data name="Registration_UnableToVerify" xml:space="preserve">
     <value>ライセンスの認証プロセスを開始する際に問題が発生しました。</value>
   </data>
+  <data name="Registration_LicensePurchaseInstruction" xml:space="preserve">
+    <value>ライセンスキーは次のサイトで登録して購入できます:</value>
+  </data>
+  <data name="Registration_DeactivationIntro" xml:space="preserve">
+    <value>このインストールでは現在ライセンスキーが使用されています。ライセンスキーを変更するか他のインストールに割り当てる場合は、このインストールのライセンスを非アクティブ化できます:</value>
+  </data>
+  <data name="Registration_DeactivateInstall" xml:space="preserve">
+    <value>インストールを無効化</value>
+  </data>
+  <data name="Registration_ApiCommunicationFailed" xml:space="preserve">
+    <value>AutoSSL API との通信に失敗しました。Web ブラウザーで https://update.autoip.com.br/v1/update にアクセスできることを確認してください。&#x0a;&#x0a;古いバージョンの Windows を使用している場合は、https://docs.certifytheweb.com の「TLS Cipher」を確認してください。レジストリ設定の更新が必要な場合があります。</value>
+  </data>
+  <data name="Registration_PluginLoadFailed" xml:space="preserve">
+    <value>ライセンス検証プラグインを読み込めませんでした。アプリを再インストールする必要があるかもしれません。</value>
+  </data>
+  <data name="Registration_DeactivateSuccess" xml:space="preserve">
+    <value>このインストールは無効化されました。別のライセンスキーを入力するか、キーを別のインストールで使用できます。</value>
+  </data>
+  <data name="Registration_DeactivateFailed" xml:space="preserve">
+    <value>インストールを無効化できませんでした。指定したメール アドレスがアカウントに正しいか確認してください。C:\ProgramData\Certify\reg_1 ファイルを手動で削除し、https://certifytheweb.com でインストールを無効化できます。</value>
+  </data>
   <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
     <value>自動更新タスクは既に設定されています。 必要に応じて、タスクの実行に使用する管理者ユーザーアカウントを変更できます。</value>
   </data>

--- a/src/Certify.Locales/SR.nb-NO.resx
+++ b/src/Certify.Locales/SR.nb-NO.resx
@@ -219,6 +219,27 @@
   <data name="Registration_UnableToVerify" xml:space="preserve">
     <value>Det oppstod et problem med godkjenningsprosessen for lisensen.</value>
   </data>
+  <data name="Registration_LicensePurchaseInstruction" xml:space="preserve">
+    <value>Du kan kjøpe en lisensnøkkel ved å registrere deg på:</value>
+  </data>
+  <data name="Registration_DeactivationIntro" xml:space="preserve">
+    <value>Installasjonen bruker for øyeblikket en lisensnøkkel. Hvis du ønsker å endre lisensnøkkel eller tildele lisensen til en annen installasjon, kan du deaktivere lisensen for denne installasjonen:</value>
+  </data>
+  <data name="Registration_DeactivateInstall" xml:space="preserve">
+    <value>Deaktiver installasjon</value>
+  </data>
+  <data name="Registration_ApiCommunicationFailed" xml:space="preserve">
+    <value>Kommunikasjonen med AutoSSL-API-en mislyktes. Kontroller at systemet ditt kan kommunisere med https://update.autoip.com.br/v1/update i en nettleser.&#x0a;&#x0a;Hvis systemet ditt kjører en eldre versjon av Windows, se https://docs.certifytheweb.com for «TLS Cipher», da oppdaterte registerinnstillinger kan være nødvendig.</value>
+  </data>
+  <data name="Registration_PluginLoadFailed" xml:space="preserve">
+    <value>Kunne ikke laste inn plugin-modulen for lisensvalidering. Appen må kanskje installeres på nytt.</value>
+  </data>
+  <data name="Registration_DeactivateSuccess" xml:space="preserve">
+    <value>Denne installasjonen er nå deaktivert. Du kan angi en annen lisensnøkkel eller bruke nøkkelen på en annen installasjon.</value>
+  </data>
+  <data name="Registration_DeactivateFailed" xml:space="preserve">
+    <value>Installasjonen kunne ikke deaktiveres. Kontroller at den angitte e-postadressen er riktig for kontoen. Du kan manuelt slette filen C:\ProgramData\Certify\reg_1 og deaktivere installasjonen på https://certifytheweb.com</value>
+  </data>
   <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
     <value>Den automatiske fornyelsesoppgaven er allerede konfigurert. Om nødvendig kan du endre admin brukerkontoen som brukes til å utføre oppgaven.</value>
   </data>

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -173,6 +173,27 @@
   <data name="Registration_UnableToVerify" xml:space="preserve">
     <value>Houve um problema ao iniciar o processo de validação da licença.</value>
   </data>
+  <data name="Registration_LicensePurchaseInstruction" xml:space="preserve">
+    <value>Você pode comprar uma chave de licença registrando-se em:</value>
+  </data>
+  <data name="Registration_DeactivationIntro" xml:space="preserve">
+    <value>Sua instalação está atualmente usando uma chave de licença. Se deseja alterar a chave ou alocar esta licença para outra instalação, você pode desativar a licença desta instalação:</value>
+  </data>
+  <data name="Registration_DeactivateInstall" xml:space="preserve">
+    <value>Desativar instalação</value>
+  </data>
+  <data name="Registration_ApiCommunicationFailed" xml:space="preserve">
+    <value>A comunicação com a API AutoSSL falhou. Verifique se o sistema pode se comunicar com https://update.autoip.com.br/v1/update usando um navegador.&#x0a;&#x0a;Se o sistema estiver executando uma versão mais antiga do Windows, consulte https://docs.certifytheweb.com sobre 'TLS Cipher', pois configurações de registro atualizadas podem ser necessárias.</value>
+  </data>
+  <data name="Registration_PluginLoadFailed" xml:space="preserve">
+    <value>Não foi possível carregar o plugin de validação de licença. Pode ser necessário reinstalar o aplicativo.</value>
+  </data>
+  <data name="Registration_DeactivateSuccess" xml:space="preserve">
+    <value>Esta instalação foi desativada. Você pode inserir uma chave de licença diferente ou usar sua chave em outra instalação.</value>
+  </data>
+  <data name="Registration_DeactivateFailed" xml:space="preserve">
+    <value>A instalação não pôde ser desativada; verifique se o endereço de e-mail especificado está correto para a conta. Você pode excluir manualmente o arquivo C:\ProgramData\Certify\reg_1 e desativar sua instalação em https://certifytheweb.com</value>
+  </data>
   <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
     <value>A tarefa de renovação automática já está configurada. Se necessário, você pode alterar a conta de usuário administrador usada para executar a tarefa.</value>
   </data>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -173,6 +173,27 @@
   <data name="Registration_UnableToVerify" xml:space="preserve">
     <value>Houve um problema ao iniciar o processo de validação da licença.</value>
   </data>
+  <data name="Registration_LicensePurchaseInstruction" xml:space="preserve">
+    <value>Você pode comprar uma chave de licença registrando-se em:</value>
+  </data>
+  <data name="Registration_DeactivationIntro" xml:space="preserve">
+    <value>Sua instalação está atualmente usando uma chave de licença. Se deseja alterar a chave ou alocar esta licença para outra instalação, você pode desativar a licença desta instalação:</value>
+  </data>
+  <data name="Registration_DeactivateInstall" xml:space="preserve">
+    <value>Desativar instalação</value>
+  </data>
+  <data name="Registration_ApiCommunicationFailed" xml:space="preserve">
+    <value>A comunicação com a API AutoSSL falhou. Verifique se o sistema pode se comunicar com https://update.autoip.com.br/v1/update usando um navegador.&#x0a;&#x0a;Se o sistema estiver executando uma versão mais antiga do Windows, consulte https://docs.certifytheweb.com sobre 'TLS Cipher', pois configurações de registro atualizadas podem ser necessárias.</value>
+  </data>
+  <data name="Registration_PluginLoadFailed" xml:space="preserve">
+    <value>Não foi possível carregar o plugin de validação de licença. Pode ser necessário reinstalar o aplicativo.</value>
+  </data>
+  <data name="Registration_DeactivateSuccess" xml:space="preserve">
+    <value>Esta instalação foi desativada. Você pode inserir uma chave de licença diferente ou usar sua chave em outra instalação.</value>
+  </data>
+  <data name="Registration_DeactivateFailed" xml:space="preserve">
+    <value>A instalação não pôde ser desativada; verifique se o endereço de e-mail especificado está correto para a conta. Você pode excluir manualmente o arquivo C:\ProgramData\Certify\reg_1 e desativar sua instalação em https://certifytheweb.com</value>
+  </data>
   <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
     <value>A tarefa de renovação automática já está configurada. Se necessário, você pode alterar a conta de usuário administrador usada para executar a tarefa.</value>
   </data>

--- a/src/Certify.Locales/SR.tr-TR.resx
+++ b/src/Certify.Locales/SR.tr-TR.resx
@@ -231,6 +231,27 @@
   <data name="Registration_UnableToVerify" xml:space="preserve">
     <value>Lisans doğrulama sürecini başlatırken bir sorun oluştu.</value>
   </data>
+  <data name="Registration_LicensePurchaseInstruction" xml:space="preserve">
+    <value>Bir lisans anahtarını şu adresten kayıt olarak satın alabilirsiniz:</value>
+  </data>
+  <data name="Registration_DeactivationIntro" xml:space="preserve">
+    <value>Kurulumunuz şu anda bir lisans anahtarı kullanıyor. Lisans anahtarını değiştirmek veya bu lisansı başka bir kuruluma tahsis etmek istiyorsanız, bu kurulum için lisansı devre dışı bırakabilirsiniz:</value>
+  </data>
+  <data name="Registration_DeactivateInstall" xml:space="preserve">
+    <value>Kurulumu devre dışı bırak</value>
+  </data>
+  <data name="Registration_ApiCommunicationFailed" xml:space="preserve">
+    <value>AutoSSL API ile iletişim başarısız oldu. Sisteminizin https://update.autoip.com.br/v1/update adresiyle bir web tarayıcısı üzerinden iletişim kurabildiğinden emin olun.&#x0a;&#x0a;Sisteminiz eski bir Windows sürümü çalıştırıyorsa, güncellenmiş kayıt ayarları gerekebileceğinden https://docs.certifytheweb.com adresinden 'TLS Cipher' konusunu kontrol edin.</value>
+  </data>
+  <data name="Registration_PluginLoadFailed" xml:space="preserve">
+    <value>Lisans doğrulama eklentisi yüklenemedi. Uygulamayı yeniden kurmanız gerekebilir.</value>
+  </data>
+  <data name="Registration_DeactivateSuccess" xml:space="preserve">
+    <value>Bu kurulum devre dışı bırakıldı. Farklı bir lisans anahtarı girebilir veya anahtarınızı başka bir kurulumda kullanabilirsiniz.</value>
+  </data>
+  <data name="Registration_DeactivateFailed" xml:space="preserve">
+    <value>Kurulum devre dışı bırakılamadı; belirtilen e-posta adresinin hesap için doğru olduğundan emin olun. C:\ProgramData\Certify\reg_1 dosyasını manuel olarak silebilir ve kurulumu https://certifytheweb.com adresinde devre dışı bırakabilirsiniz.</value>
+  </data>
   <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
     <value>Otomatik yenileme görevi zaten yapılandırılmış. Gerekirse, görevi yürütmek için kullanılan yönetici hesabını değiştirebilirsiniz.</value>
   </data>

--- a/src/Certify.Locales/SR.zh-Hans.resx
+++ b/src/Certify.Locales/SR.zh-Hans.resx
@@ -231,6 +231,27 @@
   <data name="Registration_UnableToVerify" xml:space="preserve">
     <value>启动授权密钥验证流程时出现问题。</value>
   </data>
+  <data name="Registration_LicensePurchaseInstruction" xml:space="preserve">
+    <value>您可以在以下网站注册购买许可证密钥：</value>
+  </data>
+  <data name="Registration_DeactivationIntro" xml:space="preserve">
+    <value>此安装当前正在使用许可证密钥。如果您希望更改许可证密钥或将此许可证分配给其他安装，您可以为此安装停用许可证：</value>
+  </data>
+  <data name="Registration_DeactivateInstall" xml:space="preserve">
+    <value>停用安装</value>
+  </data>
+  <data name="Registration_ApiCommunicationFailed" xml:space="preserve">
+    <value>与 AutoSSL API 通信失败。请检查系统是否可使用浏览器访问 https://update.autoip.com.br/v1/update。&#x0a;&#x0a;如果您的系统运行旧版本的 Windows，请在 https://docs.certifytheweb.com 查看“TLS Cipher”，可能需要更新注册表设置。</value>
+  </data>
+  <data name="Registration_PluginLoadFailed" xml:space="preserve">
+    <value>无法加载许可验证插件。可能需要重新安装应用。</value>
+  </data>
+  <data name="Registration_DeactivateSuccess" xml:space="preserve">
+    <value>此安装已停用。您可以输入不同的许可证密钥或在另一台安装上使用您的密钥。</value>
+  </data>
+  <data name="Registration_DeactivateFailed" xml:space="preserve">
+    <value>无法停用此安装，请检查指定的电子邮件地址是否与帐户匹配。您可以手动删除 C:\ProgramData\Certify\reg_1 文件并在 https://certifytheweb.com 上停用您的安装。</value>
+  </data>
   <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
     <value>自动续期任务已配置，如有需要可更改用于执行任务的管理员账户。</value>
   </data>

--- a/src/Certify.Locales/SR.zh-Hant.resx
+++ b/src/Certify.Locales/SR.zh-Hant.resx
@@ -231,6 +231,27 @@
   <data name="Registration_UnableToVerify" xml:space="preserve">
     <value>無法開始授權金鑰驗證程序。</value>
   </data>
+  <data name="Registration_LicensePurchaseInstruction" xml:space="preserve">
+    <value>您可以在以下網站註冊購買授權金鑰：</value>
+  </data>
+  <data name="Registration_DeactivationIntro" xml:space="preserve">
+    <value>此安裝目前正在使用授權金鑰。若您希望變更授權金鑰或將此授權分配給其他安裝，可停用此安裝的授權：</value>
+  </data>
+  <data name="Registration_DeactivateInstall" xml:space="preserve">
+    <value>停用安裝</value>
+  </data>
+  <data name="Registration_ApiCommunicationFailed" xml:space="preserve">
+    <value>與 AutoSSL API 通訊失敗。請確認系統可使用瀏覽器存取 https://update.autoip.com.br/v1/update。&#x0a;&#x0a;若系統執行較舊版本的 Windows，請至 https://docs.certifytheweb.com 查詢「TLS Cipher」，可能需要更新登錄設定。</value>
+  </data>
+  <data name="Registration_PluginLoadFailed" xml:space="preserve">
+    <value>無法載入授權驗證外掛。可能需要重新安裝應用程式。</value>
+  </data>
+  <data name="Registration_DeactivateSuccess" xml:space="preserve">
+    <value>此安裝已停用。您可以輸入不同的授權金鑰或在另一個安裝上使用您的金鑰。</value>
+  </data>
+  <data name="Registration_DeactivateFailed" xml:space="preserve">
+    <value>無法停用此安裝，請確認指定的電子郵件地址與帳戶相符。您可以手動刪除 C:\ProgramData\Certify\reg_1 檔案，並在 https://certifytheweb.com 上停用您的安裝。</value>
+  </data>
   <data name="ScheduledTaskConfig_AlreadyConfiged" xml:space="preserve">
     <value>自動續期工作已設定，若需更換執行帳號，可修改管理員使用者。</value>
   </data>

--- a/src/Certify.UI.Shared/Windows/Registration.xaml
+++ b/src/Certify.UI.Shared/Windows/Registration.xaml
@@ -26,7 +26,7 @@
         <StackPanel DockPanel.Dock="Top" Visibility="{Binding IsRegistrationMode, Converter={StaticResource ResourceKey=BoolToVisConverter}}">
 
             <Grid>
-                <TextBlock Margin="10,10,-10,-11" TextWrapping="WrapWithOverflow"><Run>You can purchase a license key by registering at:</Run><LineBreak /> <Hyperlink NavigateUri="https://certifytheweb.com/register?src=app.enterkey" RequestNavigate="Hyperlink_RequestNavigate">https://certifytheweb.com/register</Hyperlink></TextBlock>
+                <TextBlock Margin="10,10,-10,-11" TextWrapping="WrapWithOverflow"><Run Text="{x:Static res:SR.Registration_LicensePurchaseInstruction}" /><LineBreak /> <Hyperlink NavigateUri="https://certifytheweb.com/register?src=app.enterkey" RequestNavigate="Hyperlink_RequestNavigate">https://certifytheweb.com/register</Hyperlink></TextBlock>
                 <Button
                     x:Name="ValidateKey"
                     Width="112"
@@ -82,7 +82,7 @@
             DockPanel.Dock="Top"
             LastChildFill="False"
             Visibility="{Binding IsRegistrationMode, Converter={StaticResource ResourceKey=InvBoolToVisConverter}}">
-            <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap">Your installation is currently using a license key. If you wish to change license key or allocate this license to a different install you can deactivate the license for this install:</TextBlock>
+            <TextBlock DockPanel.Dock="Top" TextWrapping="Wrap" Text="{x:Static res:SR.Registration_DeactivationIntro}" />
             <StackPanel
                 Margin="8"
                 DockPanel.Dock="Top"
@@ -106,16 +106,14 @@
                     x:Name="DeactivateCancel"
                     Width="120"
                     Click="Cancel_Click"
-                    DockPanel.Dock="Left">
-                    Cancel
-                </Button>
+                    DockPanel.Dock="Left"
+                    Content="{x:Static res:SR.Cancel}" />
                 <Button
                     x:Name="Deactivate"
                     HorizontalAlignment="Right"
                     Click="Deactivate_Click"
-                    DockPanel.Dock="Right">
-                    Deactivate Install
-                </Button>
+                    DockPanel.Dock="Right"
+                    Content="{x:Static res:SR.Registration_DeactivateInstall}" />
             </DockPanel>
 
         </DockPanel>

--- a/src/Certify.UI.Shared/Windows/Registration.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/Registration.xaml.cs
@@ -95,7 +95,7 @@ namespace Certify.UI.Windows
                 catch (System.Net.Http.HttpRequestException exp)
                 {
                     Log?.Information("ValidateKey:" + exp.ToString());
-                    MessageBox.Show("Communication with the AutoSSL API failed. Check your system can communicate with https://update.autoip.com.br/v1/update using a web browser. \r\n\r\nIf your system is running an older version of Windows, check https://docs.certifytheweb.com for 'TLS Cipher', as updated registry settings may be required.");
+                    MessageBox.Show(Certify.Locales.SR.Registration_ApiCommunicationFailed);
                 }
                 catch (Exception exp)
                 {
@@ -108,7 +108,7 @@ namespace Certify.UI.Windows
             }
             else
             {
-                MessageBox.Show("Could not load the licensing validation plugin. The app may need to be re-installed.");
+                MessageBox.Show(Certify.Locales.SR.Registration_PluginLoadFailed);
             }
 
             ValidateKey.IsEnabled = true;
@@ -156,12 +156,12 @@ namespace Certify.UI.Windows
                 if (resultOK)
                 {
                     ViewModel.AppViewModel.Current.IsRegisteredVersion = false;
-                    MessageBox.Show("This install has now been deactivated. You can enter a different license key or use your key on another install.");
+                    MessageBox.Show(Certify.Locales.SR.Registration_DeactivateSuccess);
                     Close();
                 }
                 else
                 {
-                    MessageBox.Show("The install could not be deactivated, check specified email address is correct for account. You can manually delete the C:\\ProgramData\\Certify\\reg_1 file and deactivate your install on https://certifytheweb.com");
+                    MessageBox.Show(Certify.Locales.SR.Registration_DeactivateFailed);
 
                 }
             }


### PR DESCRIPTION
## Summary
- localize registration text and deactivation instructions
- centralize API communication, plugin load, and deactivation messages
- add resource entries and translations for new registration strings

## Testing
- ⚠️ `dotnet build src/Certify.UI.sln` (dotnet: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68adde9e1d68832e8580e9add32c3f6e