### PR TITLE
Translate account dialog text to Portuguese

### DIFF
--- a/src/Certify.UI.Shared/Windows/EditAccountDialog.xaml
+++ b/src/Certify.UI.Shared/Windows/EditAccountDialog.xaml
@@ -136,7 +136,7 @@
                                     Height="23"
                                     HorizontalAlignment="Left"
                                     VerticalAlignment="Top"
-                                    Controls:TextBoxHelper.Watermark="(optional) e.g. DST Root CA X3"
+                                    Controls:TextBoxHelper.Watermark="(opcional) ex.: DST Root CA X3"
                                     Text="{Binding Item.PreferredChain}"
                                     TextWrapping="Wrap" />
                             </StackPanel>
@@ -155,7 +155,7 @@
                                 Width="120"
                                 Margin="0,0,8,0"
                                 VerticalAlignment="Top"
-                                Content="Key Id" />
+                                Content="ID da Chave" />
                             <TextBox
                                 Width="300"
                                 Height="23"
@@ -172,7 +172,7 @@
                                 Width="120"
                                 Margin="0,0,8,0"
                                 VerticalAlignment="Top"
-                                Content="Key (HMAC)" />
+                                Content="Chave (HMAC)" />
                             <PasswordBox
                                 x:Name="EabKey"
                                 Width="300"
@@ -188,13 +188,13 @@
                                 Width="120"
                                 Margin="0,0,8,0"
                                 VerticalAlignment="Top"
-                                Content="Chave Algoritmo" />
+                                Content="Algoritmo da Chave" />
                             <TextBox
                                 Width="300"
                                 Height="23"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Top"
-                                Controls:TextBoxHelper.Watermark="optional, e.g. HS256 (default), HS384 or HS512"
+                                Controls:TextBoxHelper.Watermark="opcional, ex.: HS256 (padrão), HS384 ou HS512"
                                 Text="{Binding Item.EabKeyAlgorithm}"
                                 TextWrapping="Wrap" />
                         </StackPanel>

--- a/src/Certify.UI.Shared/Windows/EditAccountDialog.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/EditAccountDialog.xaml.cs
@@ -69,7 +69,7 @@ namespace Certify.UI.Windows
 
             if (ca == null)
             {
-                MessageBox.Show("Certificate authority not selected - cannot proceed. Ensure the app has loaded correctly and the Certify background service is running.");
+                MessageBox.Show("Autoridade certificadora não selecionada - não é possível continuar. Verifique se o aplicativo foi carregado corretamente e se o serviço em segundo plano do Certify está em execução.");
                 return;
             }
 
@@ -116,14 +116,14 @@ namespace Certify.UI.Windows
             {
                 if (string.IsNullOrEmpty(Item.EabKeyId) || string.IsNullOrEmpty(Item.EabKey))
                 {
-                    MessageBox.Show(string.IsNullOrEmpty(ca.EabInstructions) ? "An external account binding Key Id and (HMAC) Key are required and will be provided by your Certificate Authority. You can enter these on the Advanced tab." : ca.EabInstructions);
+                    MessageBox.Show(string.IsNullOrEmpty(ca.EabInstructions) ? "Um ID da Chave e uma Chave (HMAC) de vinculação de conta externa são necessários e serão fornecidos pela sua Autoridade Certificadora. Você pode inseri-los na guia Avançado." : ca.EabInstructions);
                     return;
                 }
             }
 
             if (Item.IsStaging && string.IsNullOrEmpty(ca.StagingAPIEndpoint))
             {
-                MessageBox.Show("This certificate authority does not have a staging (test) API so can't be used for Staging certificate requests.");
+                MessageBox.Show("Esta autoridade certificadora não possui uma API de homologação (teste), portanto não pode ser usada para solicitações de certificado de Staging.");
                 return;
             }
 
@@ -171,7 +171,7 @@ namespace Certify.UI.Windows
             var result = await MainViewModel.ChangeAccountKey(Item.StorageKey, null);
             if (result.IsSuccess)
             {
-                MainViewModel.ShowNotification("Account key changed");
+                MainViewModel.ShowNotification("Chave da conta alterada");
             }
             else
             {


### PR DESCRIPTION
## Summary
- localize key and watermark labels in account editor
- translate message box and notification strings to Portuguese

## Testing
- ⚠️ `dotnet build src/Certify.UI.sln` *(dotnet: command not found; package installation failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adde9ce7a8832e899e9171a0c31ee1