### PR TITLE
Localize data store connection messages

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -421,6 +421,69 @@ namespace Certify.Locales {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to A conexão do repositório de dados requer um título..
+        /// </summary>
+        public static string EditDataStoreConnection_TitleRequired {
+            get {
+                return ResourceManager.GetString("EditDataStoreConnection_TitleRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to É necessário um tipo de provedor..
+        /// </summary>
+        public static string EditDataStoreConnection_TypeRequired {
+            get {
+                return ResourceManager.GetString("EditDataStoreConnection_TypeRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to SQLite é o tipo de armazenamento padrão e adicionar repositórios de dados SQLite adicionais (ou editar o padrão) não é suportado no momento..
+        /// </summary>
+        public static string EditDataStoreConnection_SqliteNotSupported {
+            get {
+                return ResourceManager.GetString("EditDataStoreConnection_SqliteNotSupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to As conexões do repositório de dados exigem uma string de conexão para especificar os detalhes da fonte de dados..
+        /// </summary>
+        public static string EditDataStoreConnection_ConfigRequired {
+            get {
+                return ResourceManager.GetString("EditDataStoreConnection_ConfigRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Falha na validação ao adicionar/editar repositório de dados..
+        /// </summary>
+        public static string EditDataStoreConnection_ValidationFailed {
+            get {
+                return ResourceManager.GetString("EditDataStoreConnection_ValidationFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to O teste do repositório de dados foi bem-sucedido.
+        /// </summary>
+        public static string EditDataStoreConnection_TestSuccess {
+            get {
+                return ResourceManager.GetString("EditDataStoreConnection_TestSuccess", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Teste do repositório de dados.
+        /// </summary>
+        public static string EditDataStoreConnection_TestTitle {
+            get {
+                return ResourceManager.GetString("EditDataStoreConnection_TestTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Edit Server Connection.
         /// </summary>
         public static string EditServerConnection_Title {

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -765,6 +765,27 @@
   <data name="ClickToCopy" xml:space="preserve">
     <value>Clique para copiar para a área de transferência</value>
   </data>
+  <data name="EditDataStoreConnection_TitleRequired" xml:space="preserve">
+    <value>A conexão do repositório de dados requer um título.</value>
+  </data>
+  <data name="EditDataStoreConnection_TypeRequired" xml:space="preserve">
+    <value>É necessário um tipo de provedor.</value>
+  </data>
+  <data name="EditDataStoreConnection_SqliteNotSupported" xml:space="preserve">
+    <value>SQLite é o tipo de armazenamento padrão e adicionar repositórios de dados SQLite adicionais (ou editar o padrão) não é suportado no momento.</value>
+  </data>
+  <data name="EditDataStoreConnection_ConfigRequired" xml:space="preserve">
+    <value>As conexões do repositório de dados exigem uma string de conexão para especificar os detalhes da fonte de dados.</value>
+  </data>
+  <data name="EditDataStoreConnection_ValidationFailed" xml:space="preserve">
+    <value>Falha na validação ao adicionar/editar repositório de dados.</value>
+  </data>
+  <data name="EditDataStoreConnection_TestSuccess" xml:space="preserve">
+    <value>O teste do repositório de dados foi bem-sucedido</value>
+  </data>
+  <data name="EditDataStoreConnection_TestTitle" xml:space="preserve">
+    <value>Teste do repositório de dados</value>
+  </data>
   <data name="EditServerConnection_Title" xml:space="preserve">
     <value>Editar conexão do servidor</value>
   </data>

--- a/src/Certify.UI.Shared/Windows/EditDataStoreConnection.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/EditDataStoreConnection.xaml.cs
@@ -7,6 +7,7 @@ using Certify.Models;
 using Certify.Models.Config;
 using Certify.Shared;
 using Certify.UI.ViewModel;
+using Certify.Locales;
 using Newtonsoft.Json;
 
 namespace Certify.UI.Windows
@@ -64,27 +65,27 @@ namespace Certify.UI.Windows
 
             if (string.IsNullOrEmpty(Model.Item.Title))
             {
-                validationError = "The data store connection requires a title.";
+                validationError = SR.EditDataStoreConnection_TitleRequired;
             }
 
             if (string.IsNullOrEmpty(Model.Item.TypeId))
             {
-                validationError = "A provider type is required";
+                validationError = SR.EditDataStoreConnection_TypeRequired;
             }
 
             if (Model.Item.TypeId == "sqlite")
             {
-                validationError = "SQLite is the default store type and adding additional SQLite data stores (or editing the default one) is currently not supported";
+                validationError = SR.EditDataStoreConnection_SqliteNotSupported;
             }
 
             if (string.IsNullOrEmpty(Model.Item.ConnectionConfig))
             {
-                validationError = "Data store connections require a connection string to specify the connection details to the data source.";
+                validationError = SR.EditDataStoreConnection_ConfigRequired;
             }
 
             if (!string.IsNullOrEmpty(validationError))
             {
-                MessageBox.Show(validationError, "Add/Edit Data Store Validation Failed");
+                MessageBox.Show(validationError, SR.EditDataStoreConnection_ValidationFailed);
                 return false;
             }
             else
@@ -132,7 +133,7 @@ namespace Certify.UI.Windows
 
             if (!results.Any(r => r.HasError))
             {
-                MessageBox.Show("The data store test was successful", "Data Store Test");
+                MessageBox.Show(SR.EditDataStoreConnection_TestSuccess, SR.EditDataStoreConnection_TestTitle);
             }
             else
             {


### PR DESCRIPTION
## Summary
- replace hard-coded data store validation and test strings with localized resources
- add corresponding entries to SR.resx

## Testing
- `dotnet test src/Certify.UI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adde9709fc832ead01782296296005