### PR TITLE
Localize save button label in deployment task window

### DIFF
--- a/src/Certify.UI.Shared/Windows/EditDeploymentTask.xaml
+++ b/src/Certify.UI.Shared/Windows/EditDeploymentTask.xaml
@@ -39,7 +39,7 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Top"
                 Click="Save_Click"
-                Content="OK"
+                Content="Salvar"
                 DockPanel.Dock="Right" />
         </DockPanel>
         <ManagedCertificate:DeploymentTask


### PR DESCRIPTION
## Summary
- replace OK button text with Portuguese 'Salvar'

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68adde9155a8832e8aaa19a521c478b7