### PR TITLE
Translate credential dialog text to Brazilian Portuguese

### DIFF
--- a/src/Certify.UI.Shared/Windows/EditCredential.xaml
+++ b/src/Certify.UI.Shared/Windows/EditCredential.xaml
@@ -132,7 +132,7 @@
                 Content="Nome da Credencial" />
             <TextBox
                 Width="250"
-                Controls:TextBoxHelper.Watermark="Display name for this saved credential"
+                Controls:TextBoxHelper.Watermark="Nome de exibição para esta credencial salva"
                 Text="{Binding Item.Title}" />
         </StackPanel>
         <ScrollViewer DockPanel.Dock="Top">

--- a/src/Certify.UI.Shared/Windows/EditCredential.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/EditCredential.xaml.cs
@@ -92,13 +92,13 @@ namespace Certify.UI.Windows
 
             if (string.IsNullOrEmpty(EditViewModel.Item.Title))
             {
-                MessageBox.Show("Stored credentials require a name.");
+                MessageBox.Show("Credenciais armazenadas precisam de um nome.");
                 return;
             }
 
             if (!EditViewModel.CredentialSet.Any())
             {
-                MessageBox.Show("No credentials selected.");
+                MessageBox.Show("Nenhuma credencial selecionada.");
                 return;
             }
 
@@ -108,7 +108,7 @@ namespace Certify.UI.Windows
 
                 if (c.IsRequired && string.IsNullOrEmpty(c.Value))
                 {
-                    MessageBox.Show($"{c.Name} is a required value");
+                    MessageBox.Show($"{c.Name} é um valor obrigatório");
                     return;
                 }
 
@@ -182,7 +182,7 @@ namespace Certify.UI.Windows
                 return;
             }
 
-            if (MessageBox.Show("Are you sure you wish to delete this stored credential?", "Confirm Delete", MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
+            if (MessageBox.Show("Tem certeza de que deseja excluir esta credencial armazenada?", "Confirmar exclusão", MessageBoxButton.YesNoCancel) == MessageBoxResult.Yes)
             {
                 var result = await MainViewModel.DeleteCredential(EditViewModel.Item.StorageKey);
                 if (result.IsSuccess)


### PR DESCRIPTION
## Summary
- Translate credential watermarks and prompts to Brazilian Portuguese for EditCredential window

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68adde8fc1f8832e8e7b64bbfc712df1