### PR TITLE
Translate server connection UI to Portuguese

### DIFF
--- a/src/Certify.UI.Shared/Windows/ServerConnections.xaml
+++ b/src/Certify.UI.Shared/Windows/ServerConnections.xaml
@@ -43,7 +43,7 @@
                                 Click="Connect_Click"
                                 CommandParameter="{Binding}"
                                 DockPanel.Dock="Left"
-                                ToolTip="Connect">
+                                ToolTip="Conectar">
                                 <StackPanel Orientation="Horizontal">
                                     <fa:ImageAwesome
                                         HorizontalAlignment="Center"
@@ -116,7 +116,7 @@
                 Width="80"
                 Click="Button_Click"
                 DockPanel.Dock="Right">
-                Cancel
+                Cancelar
             </Button>
         </DockPanel>
     </DockPanel>


### PR DESCRIPTION
## Summary
- localize connect tooltip and cancel button in server connections window

## Testing
- `dotnet build src/Certify.UI.Shared/Certify.UI.Shared.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adde8d6f84832e8ed59079ba34d609