### PR TITLE
Translate main window UI elements to Portuguese

### DIFF
--- a/src/Certify.UI.Shared/Windows/MainWindow.xaml
+++ b/src/Certify.UI.Shared/Windows/MainWindow.xaml
@@ -117,7 +117,7 @@
                 <TextBlock
                     Margin="8,0,0,0"
                     VerticalAlignment="Center"
-                    Foreground="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"><Run Text="Loading.." /></TextBlock>
+                    Foreground="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"><Run Text="Carregando..." /></TextBlock>
             </StackPanel>
 
             <DockPanel
@@ -131,7 +131,7 @@
                 <Button
                     x:Name="Connect"
                     Margin="8,0,0,0"
-                    AutomationProperties.Name="Connect"
+                    AutomationProperties.Name="Conectar"
                     Click="Connect_Click"
                     DockPanel.Dock="Right">
                     <StackPanel Orientation="Horizontal">
@@ -224,7 +224,7 @@
             <Controls:Flyout
                 Name="MainFlyout"
                 Width="300"
-                Header="Flyout"
+                Header="Painel"
                 Position="Right"
                 Theme="Adapt" />
         </Controls:FlyoutsControl>

--- a/src/Certify.UI.Shared/Windows/MainWindow.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/MainWindow.xaml.cs
@@ -257,11 +257,11 @@ namespace Certify.UI.Windows
 
                 if (!string.IsNullOrEmpty(config.ServiceFaultMsg))
                 {
-                    MessageBox.Show("Certify Certificate Manager service not started. " + config.ServiceFaultMsg);
+                    MessageBox.Show("O serviço Certify Certificate Manager não foi iniciado. " + config.ServiceFaultMsg);
                 }
                 else
                 {
-                    MessageBox.Show("Certify Certificate Manager service not started. Please restart the service. If this problem persists please refer to https://docs.certifytheweb.com/docs/faq and if you cannot resolve the problem contact support@certifytheweb.com.");
+                    MessageBox.Show("O serviço Certify Certificate Manager não foi iniciado. Reinicie o serviço. Se o problema persistir, consulte https://docs.certifytheweb.com/docs/faq e, se não conseguir resolver o problema, entre em contato com support@certifytheweb.com.");
                 }
 
                 if (_appViewModel.IsFeatureEnabled(FeatureFlags.SERVER_CONNECTIONS))
@@ -397,7 +397,7 @@ namespace Certify.UI.Windows
                 if (updateCheck.MustUpdate)
                 {
                     // offer to take user to download page
-                    var gotoDownload = MessageBox.Show(Application.Current.MainWindow, updateCheck.Message.Body + "\r\nVisit download page now?", ConfigResources.AppName, MessageBoxButton.YesNo);
+                    var gotoDownload = MessageBox.Show(Application.Current.MainWindow, updateCheck.Message.Body + "\r\nVisitar página de download agora?", ConfigResources.AppName, MessageBoxButton.YesNo);
                     if (gotoDownload == MessageBoxResult.Yes)
                     {
                         Utils.Helpers.LaunchBrowser(ConfigResources.AppWebsiteURL);


### PR DESCRIPTION
## Summary
- localize loading indicator and connect automation name in main window
- translate flyout header to Portuguese
- translate service and update prompts to Portuguese

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adde8baa2c832eb579c6e02c4865fd