### PR TITLE
Enable native library self-extraction for CLI

### DIFF
--- a/src/Certify.CLI/Certify.CLI.csproj
+++ b/src/Certify.CLI/Certify.CLI.csproj
@@ -12,6 +12,7 @@
         <PublishSingleFile>true</PublishSingleFile>
         <PublishTrimmed>true</PublishTrimmed>
         <SelfContained>true</SelfContained>
+        <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
 
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug' ">


### PR DESCRIPTION
## Summary
- include native libraries in the single-file CLI bundle so they are extracted on launch

## Testing
- `dotnet publish src/Certify.CLI/Certify.CLI.csproj -c Release -r win-x86` *(fails: command not found)*
- `dotnet publish src/Certify.CLI/Certify.CLI.csproj -c Release -r win-x64` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68adef5edee0832e852b270d2c465e56