### PR TITLE
Localize update dialog and import summary strings

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -2448,5 +2448,68 @@ namespace Certify.Locales {
                 return ResourceManager.GetString("StatusLabel", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to New Update Available.
+        /// </summary>
+        public static string Update_NewAvailable {
+            get {
+                return ResourceManager.GetString("Update_NewAvailable", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Current installed version:.
+        /// </summary>
+        public static string Update_CurrentVersion {
+            get {
+                return ResourceManager.GetString("Update_CurrentVersion", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Download.
+        /// </summary>
+        public static string Update_Download {
+            get {
+                return ResourceManager.GetString("Update_Download", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Later.
+        /// </summary>
+        public static string Update_Later {
+            get {
+                return ResourceManager.GetString("Update_Later", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Download now. You will be prompted to confirm installation after the download completes.
+        /// </summary>
+        public static string Update_DownloadNow_Tip {
+            get {
+                return ResourceManager.GetString("Update_DownloadNow_Tip", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to (unknown).
+        /// </summary>
+        public static string Unknown {
+            get {
+                return ResourceManager.GetString("Unknown", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Importing from source: {0}, exported {1}, app version {2}.
+        /// </summary>
+        public static string Import_SummaryIntro {
+            get {
+                return ResourceManager.GetString("Import_SummaryIntro", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -810,4 +810,25 @@
   <data name="EditServerConnection_UseAsDefault" xml:space="preserve">
     <value>Usar como padrão</value>
   </data>
+  <data name="Update_NewAvailable" xml:space="preserve">
+    <value>Nova atualização disponível</value>
+  </data>
+  <data name="Update_CurrentVersion" xml:space="preserve">
+    <value>Versão instalada atual:</value>
+  </data>
+  <data name="Update_Download" xml:space="preserve">
+    <value>Baixar</value>
+  </data>
+  <data name="Update_Later" xml:space="preserve">
+    <value>Mais tarde</value>
+  </data>
+  <data name="Update_DownloadNow_Tip" xml:space="preserve">
+    <value>Baixar agora. Você será solicitado a confirmar a instalação após a conclusão do download.</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>(desconhecida)</value>
+  </data>
+  <data name="Import_SummaryIntro" xml:space="preserve">
+    <value>Importando da origem: {0}, exportado {1}, versão do aplicativo {2}</value>
+  </data>
 </root>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -855,4 +855,25 @@
   <data name="EditServerConnection_UseAsDefault" xml:space="preserve">
     <value>Usar como padrão</value>
   </data>
+  <data name="Update_NewAvailable" xml:space="preserve">
+    <value>New Update Available</value>
+  </data>
+  <data name="Update_CurrentVersion" xml:space="preserve">
+    <value>Current installed version:</value>
+  </data>
+  <data name="Update_Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Update_Later" xml:space="preserve">
+    <value>Later</value>
+  </data>
+  <data name="Update_DownloadNow_Tip" xml:space="preserve">
+    <value>Download now. You will be prompted to confirm installation after the download completes.</value>
+  </data>
+  <data name="Unknown" xml:space="preserve">
+    <value>(unknown)</value>
+  </data>
+  <data name="Import_SummaryIntro" xml:space="preserve">
+    <value>Importing from source: {0}, exported {1}, app version {2}</value>
+  </data>
 </root>

--- a/src/Certify.UI.Shared/Windows/ImportExport.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/ImportExport.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using Certify.Locales;
 using Certify.Models;
 using Certify.Models.Config.Migration;
 using Certify.UI.Shared;
@@ -144,7 +145,7 @@ namespace Certify.UI.Windows
 
             }
 
-            var intro = $"Importing from source: {package.SourceName}, exported {package.ExportDate.ToLongDateString()}, app version {package.SystemVersion?.ToString().AsNullWhenBlank() ?? "(unknown)"}";
+            var intro = string.Format(SR.Import_SummaryIntro, package.SourceName, package.ExportDate.ToLongDateString(), package.SystemVersion?.ToString().AsNullWhenBlank() ?? SR.Unknown);
             var markdown = GetStepsAsMarkdown(steps, title, intro);
 
             var result = Markdown.ToHtml(markdown, _markdownPipeline);

--- a/src/Certify.UI.Shared/Windows/UpdateAvailable.xaml
+++ b/src/Certify.UI.Shared/Windows/UpdateAvailable.xaml
@@ -9,7 +9,7 @@
     xmlns:local="clr-namespace:Certify.UI.Windows"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:res="clr-namespace:Certify.Locales;assembly=Certify.Locales"
-    Title="Update Available"
+    Title="{x:Static res:SR.Update_Available}"
     Width="739.386"
     Height="423"
     MinWidth="300"
@@ -29,15 +29,13 @@
         <TextBlock
             x:Name="UpdateMessage"
             DockPanel.Dock="Top"
-            Style="{StaticResource SubheadingWithMargin}">
-            New Update Available
-        </TextBlock>
+            Style="{StaticResource SubheadingWithMargin}"
+            Text="{x:Static res:SR.Update_NewAvailable}" />
         <TextBlock
             x:Name="CurrentVersionInfo"
             DockPanel.Dock="Top"
-            Style="{StaticResource Instructions}">
-            Current installed version:
-        </TextBlock>
+            Style="{StaticResource Instructions}"
+            Text="{x:Static res:SR.Update_CurrentVersion}" />
 
         <WebBrowser
             x:Name="MarkdownView"
@@ -52,28 +50,28 @@
                 x:Name="Proceed"
                 Click="Proceed_Click"
                 DockPanel.Dock="Right"
-                ToolTip="Download now. You will be prompted to confirm installation after the download completes.">
+                ToolTip="{x:Static res:SR.Update_DownloadNow_Tip}">
                 <StackPanel Orientation="Horizontal">
                     <fa:ImageAwesome
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource MahApps.Brushes.Accent}"
                         Icon="Download" />
-                    <TextBlock Margin="8,0,0,0">Download</TextBlock>
+                    <TextBlock Margin="8,0,0,0"><Run Text="{x:Static res:SR.Update_Download}" /></TextBlock>
                 </StackPanel>
             </Button>
             <Button
                 x:Name="Cancel"
                 Click="Cancel_Click"
                 DockPanel.Dock="Left"
-                ToolTip="Cancel">
+                ToolTip="{x:Static res:SR.Cancel}">
                 <StackPanel Orientation="Horizontal">
                     <fa:ImageAwesome
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         Foreground="{DynamicResource MahApps.Brushes.Accent}"
                         Icon="ArrowCircleLeft" />
-                    <TextBlock Margin="8,0,0,0">Later</TextBlock>
+                    <TextBlock Margin="8,0,0,0"><Run Text="{x:Static res:SR.Update_Later}" /></TextBlock>
                 </StackPanel>
             </Button>
         </DockPanel>

--- a/src/Certify.UI.Shared/Windows/UpdateAvailable.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/UpdateAvailable.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Certify.Locales;
 using Certify.Models;
 using Markdig;
 
@@ -57,7 +58,7 @@ namespace Certify.UI.Windows
             var showAllChanges = false;
 
             UpdateMessage.Text = _update.Message.Body;
-            CurrentVersionInfo.Text = "Versão instalada atual: " + _update.InstalledVersion.ToString();
+            CurrentVersionInfo.Text = $"{SR.Update_CurrentVersion} {_update.InstalledVersion}";
 
             var sb = new StringBuilder();
             sb.AppendLine("**Notas de versão**\n");


### PR DESCRIPTION
## Summary
- replace hardcoded update dialog strings with resource lookups
- add resource entries and pt-BR translations for update and import messages
- use localized strings in import summary and update dialog code

## Testing
- `dotnet build src/Certify.Locales/Certify.Locales.csproj` *(fails: command not found)*
- `dotnet build src/Certify.UI.Shared/Certify.UI.Shared.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfb9004e8832ea8930b91f126cc09