### PR TITLE
Localize ViewModel English strings

### DIFF
--- a/src/Certify.Locales/SR.Designer.cs
+++ b/src/Certify.Locales/SR.Designer.cs
@@ -2448,5 +2448,383 @@ namespace Certify.Locales {
                 return ResourceManager.GetString("StatusLabel", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Save this task to generate the deployment command.
+        /// </summary>
+        public static string DeploymentTasks_SaveToGenerateCommand {
+            get {
+                return ResourceManager.GetString("DeploymentTasks_SaveToGenerateCommand", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Please select the required Task Type.
+        /// </summary>
+        public static string DeploymentTasks_SelectTaskType {
+            get {
+                return ResourceManager.GetString("DeploymentTasks_SelectTaskType", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to A unique Task Name is required, this may be used later to run the task manually.
+        /// </summary>
+        public static string DeploymentTasks_NameRequired {
+            get {
+                return ResourceManager.GetString("DeploymentTasks_NameRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to A unique Task Name is required, this task name is already in use for this managed certificate.
+        /// </summary>
+        public static string DeploymentTasks_NameAlreadyUsed {
+            get {
+                return ResourceManager.GetString("DeploymentTasks_NameAlreadyUsed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Target Host name or IP is required if deployment target is not Local.
+        /// </summary>
+        public static string DeploymentTasks_TargetHostRequired {
+            get {
+                return ResourceManager.GetString("DeploymentTasks_TargetHostRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The selected target type requires specific credentials.
+        /// </summary>
+        public static string DeploymentTasks_CredentialRequired {
+            get {
+                return ResourceManager.GetString("DeploymentTasks_CredentialRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to (Unknown CA).
+        /// </summary>
+        public static string UnknownCA {
+            get {
+                return ResourceManager.GetString("UnknownCA", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to None.
+        /// </summary>
+        public static string None {
+            get {
+                return ResourceManager.GetString("None", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to (Default).
+        /// </summary>
+        public static string DefaultValue {
+            get {
+                return ResourceManager.GetString("DefaultValue", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to (Not Attempted).
+        /// </summary>
+        public static string NotAttempted {
+            get {
+                return ResourceManager.GetString("NotAttempted", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to (Empty).
+        /// </summary>
+        public static string Empty {
+            get {
+                return ResourceManager.GetString("Empty", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Auto.
+        /// </summary>
+        public static string Auto {
+            get {
+                return ResourceManager.GetString("Auto", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Certificate Authority will be automatically selected based on compatibility and the configured ACME accounts.
+        /// </summary>
+        public static string CA_AutoDescription {
+            get {
+                return ResourceManager.GetString("CA_AutoDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to (No Password).
+        /// </summary>
+        public static string NoPassword {
+            get {
+                return ResourceManager.GetString("NoPassword", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to * (All Unassigned).
+        /// </summary>
+        public static string IPAddress_AllUnassigned {
+            get {
+                return ResourceManager.GetString("IPAddress_AllUnassigned", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to No item selected.
+        /// </summary>
+        public static string Validation_NoItemSelected {
+            get {
+                return ResourceManager.GetString("Validation_NoItemSelected", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You have added a wildcard domain, you will also need to configure a corresponding DNS challenge under Authorization.
+        /// </summary>
+        public static string ManagedCertificate_WildcardRequiresDnsChallenge {
+            get {
+                return ResourceManager.GetString("ManagedCertificate_WildcardRequiresDnsChallenge", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to You had added wildcard domains without the corresponding non-wildcard version: {0}. Would you like to add the non-wildcard versions as well?
+        /// </summary>
+        public static string ManagedCertificate_WildcardAddPrompt {
+            get {
+                return ResourceManager.GetString("ManagedCertificate_WildcardAddPrompt", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Add non-wildcard equivalent domains?.
+        /// </summary>
+        public static string ManagedCertificate_WildcardAddTitle {
+            get {
+                return ResourceManager.GetString("ManagedCertificate_WildcardAddTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Page {0} of {1}.
+        /// </summary>
+        public static string PageXofY {
+            get {
+                return ResourceManager.GetString("PageXofY", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This item is externally managed and cannot be deleted by this app.
+        /// </summary>
+        public static string ManagedCertificates_ExternalDeletionNotAllowed {
+            get {
+                return ResourceManager.GetString("ManagedCertificates_ExternalDeletionNotAllowed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Starting...
+        /// </summary>
+        public static string Starting {
+            get {
+                return ResourceManager.GetString("Starting", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The test took too long to complete and has timed out. Please check and try again.
+        /// </summary>
+        public static string Operation_TestTimeout {
+            get {
+                return ResourceManager.GetString("Operation_TestTimeout", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The operation took too long to complete and has timed out. Please check and try again.
+        /// </summary>
+        public static string Operation_Timeout {
+            get {
+                return ResourceManager.GetString("Operation_Timeout", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred. Persistent errors should be reported to AutoSSL support: {0}.
+        /// </summary>
+        public static string Error_PersistentContactSupport {
+            get {
+                return ResourceManager.GetString("Error_PersistentContactSupport", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Received: {0} {1}.
+        /// </summary>
+        public static string ReceivedMessage {
+            get {
+                return ResourceManager.GetString("ReceivedMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} [{1}].
+        /// </summary>
+        public static string AccountTitleFormat {
+            get {
+                return ResourceManager.GetString("AccountTitleFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Staging.
+        /// </summary>
+        public static string Staging {
+            get {
+                return ResourceManager.GetString("Staging", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Production.
+        /// </summary>
+        public static string Production {
+            get {
+                return ResourceManager.GetString("Production", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Contact Registration could not be completed. [{0}]
+        /// </summary>
+        public static string ContactRegistrationFailed {
+            get {
+                return ResourceManager.GetString("ContactRegistrationFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Account update could not be completed. [{0}]
+        /// </summary>
+        public static string AccountUpdateFailed {
+            get {
+                return ResourceManager.GetString("AccountUpdateFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot delete. Credential key not specified.
+        /// </summary>
+        public static string CredentialKeyNotSpecified {
+            get {
+                return ResourceManager.GetString("CredentialKeyNotSpecified", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Light Theme.
+        /// </summary>
+        public static string UITheme_Light {
+            get {
+                return ResourceManager.GetString("UITheme_Light", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Dark Theme.
+        /// </summary>
+        public static string UITheme_Dark {
+            get {
+                return ResourceManager.GetString("UITheme_Dark", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to (default).
+        /// </summary>
+        public static string DefaultInBrackets {
+            get {
+                return ResourceManager.GetString("DefaultInBrackets", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to save preferences. {0}.
+        /// </summary>
+        public static string SavePreferencesError {
+            get {
+                return ResourceManager.GetString("SavePreferencesError", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Save Preferences Error.
+        /// </summary>
+        public static string SavePreferencesError_Title {
+            get {
+                return ResourceManager.GetString("SavePreferencesError_Title", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This is an example renewal failure message. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        /// </summary>
+        public static string Design_RenewalFailureMessageExample {
+            get {
+                return ResourceManager.GetString("Design_RenewalFailureMessageExample", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This is an example configuration test result.
+        /// </summary>
+        public static string Design_ConfigTestResultExample {
+            get {
+                return ResourceManager.GetString("Design_ConfigTestResultExample", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This is a failure message.
+        /// </summary>
+        public static string Design_FailureMessageExample {
+            get {
+                return ResourceManager.GetString("Design_FailureMessageExample", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This is a long message to test text overflow and wrapping.
+        /// </summary>
+        public static string Design_LongMessage {
+            get {
+                return ResourceManager.GetString("Design_LongMessage", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This is another long message to test text overflow and wrapping.
+        /// </summary>
+        public static string Design_LongMessageAlt {
+            get {
+                return ResourceManager.GetString("Design_LongMessageAlt", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Certify.Locales/SR.pt-BR.resx
+++ b/src/Certify.Locales/SR.pt-BR.resx
@@ -810,4 +810,130 @@
   <data name="EditServerConnection_UseAsDefault" xml:space="preserve">
     <value>Usar como padrão</value>
   </data>
+  <data name="DeploymentTasks_SaveToGenerateCommand" xml:space="preserve">
+    <value>Salve esta tarefa para gerar o comando de implantação</value>
+  </data>
+  <data name="DeploymentTasks_SelectTaskType" xml:space="preserve">
+    <value>Selecione o Tipo de Tarefa obrigatório.</value>
+  </data>
+  <data name="DeploymentTasks_NameRequired" xml:space="preserve">
+    <value>É necessário um Nome de Tarefa exclusivo; ele poderá ser usado posteriormente para executar a tarefa manualmente.</value>
+  </data>
+  <data name="DeploymentTasks_NameAlreadyUsed" xml:space="preserve">
+    <value>É necessário um Nome de Tarefa exclusivo; este nome de tarefa já está em uso para este certificado gerenciado.</value>
+  </data>
+  <data name="DeploymentTasks_TargetHostRequired" xml:space="preserve">
+    <value>Nome ou IP do Host de destino é necessário se o destino da implantação não for Local.</value>
+  </data>
+  <data name="DeploymentTasks_CredentialRequired" xml:space="preserve">
+    <value>O tipo de destino selecionado requer credenciais específicas.</value>
+  </data>
+  <data name="UnknownCA" xml:space="preserve">
+    <value>(AC Desconhecida)</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Nenhum</value>
+  </data>
+  <data name="DefaultValue" xml:space="preserve">
+    <value>(Padrão)</value>
+  </data>
+  <data name="NotAttempted" xml:space="preserve">
+    <value>(Não Tentado)</value>
+  </data>
+  <data name="Empty" xml:space="preserve">
+    <value>(Vazio)</value>
+  </data>
+  <data name="Auto" xml:space="preserve">
+    <value>Automático</value>
+  </data>
+  <data name="CA_AutoDescription" xml:space="preserve">
+    <value>A Autoridade Certificadora será selecionada automaticamente com base na compatibilidade e nas contas ACME configuradas.</value>
+  </data>
+  <data name="NoPassword" xml:space="preserve">
+    <value>(Sem Senha)</value>
+  </data>
+  <data name="IPAddress_AllUnassigned" xml:space="preserve">
+    <value>* (Todos Não Atribuídos)</value>
+  </data>
+  <data name="Validation_NoItemSelected" xml:space="preserve">
+    <value>Nenhum item selecionado</value>
+  </data>
+  <data name="ManagedCertificate_WildcardRequiresDnsChallenge" xml:space="preserve">
+    <value>Você adicionou um domínio curinga; também será necessário configurar um desafio DNS correspondente em Autorização.</value>
+  </data>
+  <data name="ManagedCertificate_WildcardAddPrompt" xml:space="preserve">
+    <value>Você adicionou domínios curingas sem a versão correspondente não curinga: {0}. Deseja adicionar as versões não curingas também?</value>
+  </data>
+  <data name="ManagedCertificate_WildcardAddTitle" xml:space="preserve">
+    <value>Adicionar domínios equivalentes não curingas?</value>
+  </data>
+  <data name="PageXofY" xml:space="preserve">
+    <value>Página {0} de {1}</value>
+  </data>
+  <data name="ManagedCertificates_ExternalDeletionNotAllowed" xml:space="preserve">
+    <value>Este item é gerenciado externamente e não pode ser excluído por este aplicativo.</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Iniciando..</value>
+  </data>
+  <data name="Operation_TestTimeout" xml:space="preserve">
+    <value>O teste demorou muito para concluir e expirou. Verifique e tente novamente.</value>
+  </data>
+  <data name="Operation_Timeout" xml:space="preserve">
+    <value>A operação demorou muito para concluir e expirou. Verifique e tente novamente.</value>
+  </data>
+  <data name="Error_PersistentContactSupport" xml:space="preserve">
+    <value>Ocorreu um erro. Erros persistentes devem ser relatados ao suporte do AutoSSL: {0}</value>
+  </data>
+  <data name="ReceivedMessage" xml:space="preserve">
+    <value>Recebido: {0} {1}</value>
+  </data>
+  <data name="AccountTitleFormat" xml:space="preserve">
+    <value>{0} [{1}]</value>
+  </data>
+  <data name="Staging" xml:space="preserve">
+    <value>Teste</value>
+  </data>
+  <data name="Production" xml:space="preserve">
+    <value>Produção</value>
+  </data>
+  <data name="ContactRegistrationFailed" xml:space="preserve">
+    <value>O Registro de Contato não pôde ser concluído. [{0}]</value>
+  </data>
+  <data name="AccountUpdateFailed" xml:space="preserve">
+    <value>A atualização da conta não pôde ser concluída. [{0}]</value>
+  </data>
+  <data name="CredentialKeyNotSpecified" xml:space="preserve">
+    <value>Não é possível excluir. Chave da credencial não especificada</value>
+  </data>
+  <data name="UITheme_Light" xml:space="preserve">
+    <value>Tema Claro</value>
+  </data>
+  <data name="UITheme_Dark" xml:space="preserve">
+    <value>Tema Escuro</value>
+  </data>
+  <data name="DefaultInBrackets" xml:space="preserve">
+    <value>(padrão)</value>
+  </data>
+  <data name="SavePreferencesError" xml:space="preserve">
+    <value>Não foi possível salvar as preferências. {0}.</value>
+  </data>
+  <data name="SavePreferencesError_Title" xml:space="preserve">
+    <value>Erro ao Salvar Preferências</value>
+  </data>
+  <data name="Design_RenewalFailureMessageExample" xml:space="preserve">
+    <value>Esta é uma mensagem de falha de renovação de exemplo. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</value>
+  </data>
+  <data name="Design_ConfigTestResultExample" xml:space="preserve">
+    <value>Este é um exemplo de resultado de teste de configuração.</value>
+  </data>
+  <data name="Design_FailureMessageExample" xml:space="preserve">
+    <value>Esta é uma mensagem de falha.</value>
+  </data>
+  <data name="Design_LongMessage" xml:space="preserve">
+    <value>Esta é uma mensagem longa para testar overflow e quebra de texto</value>
+  </data>
+  <data name="Design_LongMessageAlt" xml:space="preserve">
+    <value>Esta é outra mensagem longa para testar overflow e quebra de texto</value>
+  </data>
 </root>

--- a/src/Certify.Locales/SR.resx
+++ b/src/Certify.Locales/SR.resx
@@ -855,4 +855,130 @@
   <data name="EditServerConnection_UseAsDefault" xml:space="preserve">
     <value>Usar como padrão</value>
   </data>
+  <data name="DeploymentTasks_SaveToGenerateCommand" xml:space="preserve">
+    <value>Save this task to generate the deployment command</value>
+  </data>
+  <data name="DeploymentTasks_SelectTaskType" xml:space="preserve">
+    <value>Please select the required Task Type.</value>
+  </data>
+  <data name="DeploymentTasks_NameRequired" xml:space="preserve">
+    <value>A unique Task Name is required, this may be used later to run the task manually.</value>
+  </data>
+  <data name="DeploymentTasks_NameAlreadyUsed" xml:space="preserve">
+    <value>A unique Task Name is required, this task name is already in use for this managed certificate.</value>
+  </data>
+  <data name="DeploymentTasks_TargetHostRequired" xml:space="preserve">
+    <value>Target Host name or IP is required if deployment target is not Local.</value>
+  </data>
+  <data name="DeploymentTasks_CredentialRequired" xml:space="preserve">
+    <value>The selected target type requires specific credentials.</value>
+  </data>
+  <data name="UnknownCA" xml:space="preserve">
+    <value>(Unknown CA)</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="DefaultValue" xml:space="preserve">
+    <value>(Default)</value>
+  </data>
+  <data name="NotAttempted" xml:space="preserve">
+    <value>(Not Attempted)</value>
+  </data>
+  <data name="Empty" xml:space="preserve">
+    <value>(Empty)</value>
+  </data>
+  <data name="Auto" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="CA_AutoDescription" xml:space="preserve">
+    <value>The Certificate Authority will be automatically selected based on compatibility and the configured ACME accounts.</value>
+  </data>
+  <data name="NoPassword" xml:space="preserve">
+    <value>(No Password)</value>
+  </data>
+  <data name="IPAddress_AllUnassigned" xml:space="preserve">
+    <value>* (All Unassigned)</value>
+  </data>
+  <data name="Validation_NoItemSelected" xml:space="preserve">
+    <value>No item selected</value>
+  </data>
+  <data name="ManagedCertificate_WildcardRequiresDnsChallenge" xml:space="preserve">
+    <value>You have added a wildcard domain, you will also need to configure a corresponding DNS challenge under Authorization.</value>
+  </data>
+  <data name="ManagedCertificate_WildcardAddPrompt" xml:space="preserve">
+    <value>You had added wildcard domains without the corresponding non-wildcard version: {0}. Would you like to add the non-wildcard versions as well?</value>
+  </data>
+  <data name="ManagedCertificate_WildcardAddTitle" xml:space="preserve">
+    <value>Add non-wildcard equivalent domains?</value>
+  </data>
+  <data name="PageXofY" xml:space="preserve">
+    <value>Page {0} of {1}</value>
+  </data>
+  <data name="ManagedCertificates_ExternalDeletionNotAllowed" xml:space="preserve">
+    <value>This item is externally managed and cannot be deleted by this app.</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Starting..</value>
+  </data>
+  <data name="Operation_TestTimeout" xml:space="preserve">
+    <value>The test took too long to complete and has timed out. Please check and try again.</value>
+  </data>
+  <data name="Operation_Timeout" xml:space="preserve">
+    <value>The operation took too long to complete and has timed out. Please check and try again.</value>
+  </data>
+  <data name="Error_PersistentContactSupport" xml:space="preserve">
+    <value>An error occurred. Persistent errors should be reported to AutoSSL support: {0}</value>
+  </data>
+  <data name="ReceivedMessage" xml:space="preserve">
+    <value>Received: {0} {1}</value>
+  </data>
+  <data name="AccountTitleFormat" xml:space="preserve">
+    <value>{0} [{1}]</value>
+  </data>
+  <data name="Staging" xml:space="preserve">
+    <value>Staging</value>
+  </data>
+  <data name="Production" xml:space="preserve">
+    <value>Production</value>
+  </data>
+  <data name="ContactRegistrationFailed" xml:space="preserve">
+    <value>Contact Registration could not be completed. [{0}]</value>
+  </data>
+  <data name="AccountUpdateFailed" xml:space="preserve">
+    <value>Account update could not be completed. [{0}]</value>
+  </data>
+  <data name="CredentialKeyNotSpecified" xml:space="preserve">
+    <value>Cannot delete. Credential key not specified</value>
+  </data>
+  <data name="UITheme_Light" xml:space="preserve">
+    <value>Light Theme</value>
+  </data>
+  <data name="UITheme_Dark" xml:space="preserve">
+    <value>Dark Theme</value>
+  </data>
+  <data name="DefaultInBrackets" xml:space="preserve">
+    <value>(default)</value>
+  </data>
+  <data name="SavePreferencesError" xml:space="preserve">
+    <value>Unable to save preferences. {0}.</value>
+  </data>
+  <data name="SavePreferencesError_Title" xml:space="preserve">
+    <value>Save Preferences Error</value>
+  </data>
+  <data name="Design_RenewalFailureMessageExample" xml:space="preserve">
+    <value>This is an example renewal failure message. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</value>
+  </data>
+  <data name="Design_ConfigTestResultExample" xml:space="preserve">
+    <value>This is an example configuration test result.</value>
+  </data>
+  <data name="Design_FailureMessageExample" xml:space="preserve">
+    <value>This is a failure message.</value>
+  </data>
+  <data name="Design_LongMessage" xml:space="preserve">
+    <value>This is a long message to test text overflow and wrapping</value>
+  </data>
+  <data name="Design_LongMessageAlt" xml:space="preserve">
+    <value>This is another long message to test text overflow and wrapping</value>
+  </data>
 </root>

--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewMode.Design.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewMode.Design.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Certify.Models;
 using Certify.Models.Utils;
 using Newtonsoft.Json;
+using Certify.Locales;
 
 namespace Certify.UI
 {
@@ -89,8 +90,8 @@ namespace Certify.UI
 
             ProgressResults = new ObservableCollection<RequestProgressState>
             {
-                new RequestProgressState( RequestState.Running, "This is a long message to test text overflow and wrapping", ManagedCertificates[0], false),
-                new RequestProgressState( RequestState.Error, "This is another long message to test text overflow and wrapping", ManagedCertificates[1], false),
+                new RequestProgressState( RequestState.Running, SR.Design_LongMessage, ManagedCertificates[0], false),
+                new RequestProgressState( RequestState.Error, SR.Design_LongMessageAlt, ManagedCertificates[1], false),
             };
 
             AccountDetails = new ObservableCollection<AccountDetails>

--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Config.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Config.cs
@@ -9,6 +9,7 @@ using Certify.Models.Config;
 using Certify.Models.Providers;
 using Certify.Models.Utils;
 using Certify.Shared;
+using Certify.Locales;
 
 namespace Certify.UI.ViewModel
 {
@@ -101,7 +102,7 @@ namespace Certify.UI.ViewModel
             foreach (var a in list)
             {
                 var ca = CertificateAuthorities.FirstOrDefault(c => c.Id == a.CertificateAuthorityId);
-                a.Title = $"{ca?.Title.AsNullWhenBlank() ?? "[Unknown CA]"} [{(a.IsStagingAccount ? "Staging" : "Production")}]";
+                a.Title = string.Format(SR.AccountTitleFormat, ca?.Title.AsNullWhenBlank() ?? SR.UnknownCA, a.IsStagingAccount ? SR.Staging : SR.Production);
                 tmpList.Add(a);
             }
 
@@ -132,7 +133,7 @@ namespace Certify.UI.ViewModel
             }
             catch (Exception exp)
             {
-                return new ActionResult("Contact Registration could not be completed. [" + exp.Message + "]", false);
+                return new ActionResult(string.Format(SR.ContactRegistrationFailed, exp.Message), false);
             }
         }
 
@@ -147,7 +148,7 @@ namespace Certify.UI.ViewModel
             }
             catch (Exception exp)
             {
-                return new ActionResult("Account update could not be completed. [" + exp.Message + "]", false);
+                return new ActionResult(string.Format(SR.AccountUpdateFailed, exp.Message), false);
             }
         }
 
@@ -204,7 +205,7 @@ namespace Certify.UI.ViewModel
         {
             if (credentialKey == null)
             {
-                return new ActionResult("Cannot delete. Credential key not specified", isSuccess: false);
+                return new ActionResult(SR.CredentialKeyNotSpecified, isSuccess: false);
             }
 
             var result = await _certifyClient.DeleteCredential(credentialKey);

--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.ManagedCertificates.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.ManagedCertificates.cs
@@ -155,7 +155,7 @@ namespace Certify.UI.ViewModel
         /// </summary>
         public string ResultPageDescription
         {
-            get { return $"Page {_filterPageIndex + 1} of {Math.Ceiling((decimal)TotalManagedCertificates / _filterPageSize)}"; }
+            get { return string.Format(SR.PageXofY, _filterPageIndex + 1, Math.Ceiling((decimal)TotalManagedCertificates / _filterPageSize)); }
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Certify.UI.ViewModel
             {
                 if (existing.ItemType == ManagedCertificateType.SSL_ExternallyManaged)
                 {
-                    MessageBox.Show("This item is externally managed and cannot be deleted by this app.");
+                    MessageBox.Show(SR.ManagedCertificates_ExternalDeletionNotAllowed);
 
                     return false;
                 }
@@ -283,7 +283,7 @@ namespace Certify.UI.ViewModel
         public void TrackProgress(ManagedCertificate managedCertificate)
         {
             //add request to observable list of progress state
-            var progressState = new RequestProgressState(RequestState.Running, "Starting..", managedCertificate);
+            var progressState = new RequestProgressState(RequestState.Running, SR.Starting, managedCertificate);
 
             //begin monitoring progress
             UpdateRequestTrackingProgress(progressState);
@@ -472,7 +472,7 @@ namespace Certify.UI.ViewModel
                 {
                     new StatusMessage
                     {
-                        IsOK = false, Message = "The test took too long to complete and has timed out. Please check and try again."
+                        IsOK = false, Message = SR.Operation_TestTimeout
                     }
                 };
             }
@@ -490,7 +490,7 @@ namespace Certify.UI.ViewModel
                 {
                     new StatusMessage
                     {
-                        IsOK = false, Message = "The operation took too long to complete and has timed out. Please check and try again."
+                        IsOK = false, Message = SR.Operation_Timeout
                     }
                 };
             }

--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Settings.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Settings.cs
@@ -9,6 +9,7 @@ using Certify.Client;
 using Certify.Models;
 using Certify.Models.Config.Migration;
 using Certify.UI.Settings;
+using Certify.Locales;
 
 namespace Certify.UI.ViewModel
 {
@@ -43,8 +44,8 @@ namespace Certify.UI.ViewModel
         /// </summary>
         public Dictionary<string, string> UIThemes { get; } = new Dictionary<string, string>
         {
-              {"Light","Light Theme"},
-              {"Dark","Dark Theme" }
+              {"Light",SR.UITheme_Light},
+              {"Dark",SR.UITheme_Dark }
         };
 
         /// <summary>
@@ -128,7 +129,7 @@ namespace Certify.UI.ViewModel
                 // set datastoreid and feature flags to pass model validation
                 if (Preferences.ConfigDataStoreConnectionId == null)
                 {
-                    Preferences.ConfigDataStoreConnectionId = "(default)";
+                    Preferences.ConfigDataStoreConnectionId = SR.DefaultInBrackets;
                 }
 
                 if (Preferences.FeatureFlags == null)
@@ -141,7 +142,7 @@ namespace Certify.UI.ViewModel
             }
             catch (ServiceCommsException ex)
             {
-                MessageBox.Show($"Unable to save preferences. {ex?.Message}.", "Save Preferences Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(string.Format(SR.SavePreferencesError, ex?.Message), SR.SavePreferencesError_Title, MessageBoxButton.OK, MessageBoxImage.Error);
 
             }
             catch

--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.cs
@@ -12,6 +12,7 @@ using Certify.Models.Config;
 using Certify.Models.Providers;
 using Certify.Providers;
 using Certify.SharedUtils;
+using Certify.Locales;
 using Certify.UI.Shared;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -164,7 +165,7 @@ namespace Certify.UI.ViewModel
             IsError = true;
             CurrentError = exp.Message;
 
-            SystemDiagnosticError = "An error occurred. Persistent errors should be reported to AutoSSL support: " + exp.Message;
+            SystemDiagnosticError = string.Format(SR.Error_PersistentContactSupport, exp.Message);
         }
 
         /// <summary>
@@ -187,7 +188,7 @@ namespace Certify.UI.ViewModel
         /// </summary>
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
-        private void CertifyClient_SendMessage(string arg1, string arg2) => MessageBox.Show($"Received: {arg1} {arg2}");
+        private void CertifyClient_SendMessage(string arg1, string arg2) => MessageBox.Show(string.Format(SR.ReceivedMessage, arg1, arg2));
 
         public Application GetApplication() => System.Windows.Application.Current;
 

--- a/src/Certify.UI.Shared/ViewModel/DeploymentTaskConfigViewModel.cs
+++ b/src/Certify.UI.Shared/ViewModel/DeploymentTaskConfigViewModel.cs
@@ -8,6 +8,7 @@ using System.Windows.Data;
 using Certify.Config;
 using Certify.Models;
 using Certify.Models.Config;
+using Certify.Locales;
 using PropertyChanged;
 
 namespace Certify.UI.ViewModel
@@ -276,7 +277,7 @@ namespace Certify.UI.ViewModel
                 }
                 else
                 {
-                    return "[Save this task to generate the deployment command]";
+                    return SR.DeploymentTasks_SaveToGenerateCommand;
                 }
             }
         }
@@ -324,7 +325,7 @@ namespace Certify.UI.ViewModel
 
             if (SelectedItem.TaskTypeId == null)
             {
-                return new ActionResult("Please select the required Task Type.", false);
+                return new ActionResult(SR.DeploymentTasks_SelectTaskType, false);
             }
 
             if (string.IsNullOrEmpty(SelectedItem.TaskName))
@@ -340,7 +341,7 @@ namespace Certify.UI.ViewModel
             {
 
                 // check task name populated
-                return new ActionResult("A unique Task Name is required, this may be used later to run the task manually.", false);
+                return new ActionResult(SR.DeploymentTasks_NameRequired, false);
 
             }
             else
@@ -351,7 +352,7 @@ namespace Certify.UI.ViewModel
                     || _appViewModel.SelectedItem.PreRequestTasks?.Any(t => t.Id != SelectedItem.Id && t.TaskName.ToLower().Trim() == SelectedItem.TaskName.ToLower().Trim()) == true
                  )
                 {
-                    return new ActionResult("A unique Task Name is required, this task name is already in use for this managed certificate.", false);
+                    return new ActionResult(SR.DeploymentTasks_NameAlreadyUsed, false);
 
                 }
             }
@@ -370,7 +371,7 @@ namespace Certify.UI.ViewModel
                     )
                 {
                     // check task name populated
-                    return new ActionResult("Target Host name or IP is required if deployment target is not Local.", false);
+                    return new ActionResult(SR.DeploymentTasks_TargetHostRequired, false);
                 }
             }
 
@@ -378,7 +379,7 @@ namespace Certify.UI.ViewModel
 
             if (UsesCredentials && string.IsNullOrEmpty(SelectedItem.ChallengeCredentialKey))
             {
-                return new ActionResult("The selected target type requires specific credentials.", false);
+                return new ActionResult(SR.DeploymentTasks_CredentialRequired, false);
             }
 
             // validate task provider specific config
@@ -431,7 +432,7 @@ namespace Certify.UI.ViewModel
                 }
             }
 
-            return new ActionResult("OK", true);
+            return new ActionResult(SR.OK, true);
         }
     }
 }

--- a/src/Certify.UI.Shared/ViewModel/ManagedCertificateViewModel.Design.cs
+++ b/src/Certify.UI.Shared/ViewModel/ManagedCertificateViewModel.Design.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Certify.Models;
+using Certify.Locales;
 
 namespace Certify.UI
 {
@@ -20,17 +21,17 @@ namespace Certify.UI
             SelectedItem = _appViewModel.ManagedCertificates.First();
 
             SelectedItem.RenewalFailureCount = 3;
-            SelectedItem.RenewalFailureMessage = "This is an example renewal failure message. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+            SelectedItem.RenewalFailureMessage = SR.Design_RenewalFailureMessageExample;
             SelectedItem.DateLastRenewalAttempt = DateTimeOffset.UtcNow.AddMinutes(-30);
 
             ConfigCheckResults = new System.Collections.ObjectModel.ObservableCollection<StatusMessage> {
                     new StatusMessage{
                         IsOK =true,
-                        Message ="This is an example configuration test result."
+                        Message = SR.Design_ConfigTestResultExample
                     },
                      new StatusMessage{
                         IsOK =false,
-                        Message ="This is a failure message."
+                        Message = SR.Design_FailureMessageExample
                     }
                 };
 

--- a/src/Certify.UI.Shared/ViewModel/ManagedCertificateViewModel.cs
+++ b/src/Certify.UI.Shared/ViewModel/ManagedCertificateViewModel.cs
@@ -86,11 +86,11 @@ namespace Certify.UI.ViewModel
                     }
 
                     var ca = CertificateAuthorities.FirstOrDefault(c => c.Id == SelectedItem.CertificateAuthorityId);
-                    return ca?.Description.AsNullWhenBlank() ?? "(CA Unknown)";
+                    return ca?.Description.AsNullWhenBlank() ?? SR.UnknownCA;
                 }
                 else
                 {
-                    return "None";
+                    return SR.None;
                 }
             }
         }
@@ -107,11 +107,11 @@ namespace Certify.UI.ViewModel
                     }
 
                     var ca = CertificateAuthorities.FirstOrDefault(c => c.Id == SelectedItem.CertificateAuthorityId);
-                    return ca?.Title.AsNullWhenBlank() ?? "(Default)";
+                    return ca?.Title.AsNullWhenBlank() ?? SR.DefaultValue;
                 }
                 else
                 {
-                    return "None";
+                    return SR.None;
                 }
             }
         }
@@ -122,7 +122,7 @@ namespace Certify.UI.ViewModel
                 if (!string.IsNullOrEmpty(SelectedItem?.LastAttemptedCA))
                 {
                     var ca = CertificateAuthorities.FirstOrDefault(c => c.Id == SelectedItem.LastAttemptedCA);
-                    return ca?.Title.AsNullWhenBlank() ?? "(Not Attempted)";
+                    return ca?.Title.AsNullWhenBlank() ?? SR.NotAttempted;
                 }
                 else
                 {
@@ -284,9 +284,9 @@ namespace Certify.UI.ViewModel
                 {
                     _certificateAuthorities.Insert(0, new CertificateAuthority
                     {
-                        Id = "(Empty)",
-                        Title = "Auto",
-                        Description = "The Certificate Authority will be automatically selected based on compatibility and the configured ACME accounts."
+                        Id = SR.Empty,
+                        Title = SR.Auto,
+                        Description = SR.CA_AutoDescription
                     });
 
                     if (caList != null)
@@ -326,8 +326,8 @@ namespace Certify.UI.ViewModel
                 {
                     _storedPasswords.Insert(0, new Models.Config.StoredCredential
                     {
-                        StorageKey = "(Empty)",
-                        Title = "(No Password)",
+                        StorageKey = SR.Empty,
+                        Title = SR.NoPassword,
                         ProviderType = StandardAuthTypes.STANDARD_AUTH_PASSWORD
                     });
 
@@ -386,7 +386,7 @@ namespace Certify.UI.ViewModel
                 {
                     var ipAddressOptions = Certify.Utils.Networking.GetIPAddresses();
 
-                    ipAddressOptions.Insert(0, new IPAddressOption { Description = "* (All Unassigned)", IPAddress = "*", IsIPv6 = false }); //add wildcard option
+                    ipAddressOptions.Insert(0, new IPAddressOption { Description = SR.IPAddress_AllUnassigned, IPAddress = "*", IsIPv6 = false }); //add wildcard option
 
                     return ipAddressOptions;
                 }
@@ -542,7 +542,7 @@ namespace Certify.UI.ViewModel
 
             if (SelectedItem == null)
             {
-                return new ValidationResult(false, "No item selected", ValidationErrorCodes.ITEM_NOT_FOUND.ToString());
+                return new ValidationResult(false, SR.Validation_NoItemSelected, ValidationErrorCodes.ITEM_NOT_FOUND.ToString());
             }
 
             var caId = Preferences.DefaultCertificateAuthority.WithDefault(StandardCertAuthorities.LETS_ENCRYPT);
@@ -599,7 +599,7 @@ namespace Certify.UI.ViewModel
             if (result.wildcardAdded && !SelectedItem.RequestConfig.Challenges.Any(c => c.ChallengeType == SupportedChallengeTypes.CHALLENGE_TYPE_DNS))
             {
                 // wildcard added but no DNS challenges exist yet
-                MessageBox.Show("You have added a wildcard domain, you will also need to configure a corresponding DNS challenge under Authorization. ");
+                MessageBox.Show(SR.ManagedCertificate_WildcardRequiresDnsChallenge);
             }
 
             if (result.wildcardAdded)
@@ -608,8 +608,8 @@ namespace Certify.UI.ViewModel
                 var wildcardOnlyDomains = result.domainList.Where(d => d.StartsWith("*.") && !item.DomainOptions.Any(o => o.Domain == d.Replace("*.", "")));
                 if (wildcardOnlyDomains.Any())
                 {
-                    var msg = $"You had added wildcard domains without the corresponding non-wildcard version: {string.Join(",", wildcardOnlyDomains)}. Would you like to add the non-wildcard versions as well?";
-                    if (MessageBox.Show(msg, "Add non-wildcard equivalent domains?", MessageBoxButton.YesNo) == MessageBoxResult.Yes)
+                    var msg = string.Format(SR.ManagedCertificate_WildcardAddPrompt, string.Join(",", wildcardOnlyDomains));
+                    if (MessageBox.Show(msg, SR.ManagedCertificate_WildcardAddTitle, MessageBoxButton.YesNo) == MessageBoxResult.Yes)
                     {
 
                         var addedDomains = string.Join(";", wildcardOnlyDomains);


### PR DESCRIPTION
## Summary
- replace hardcoded messages in ViewModels with localized resource lookups
- add English and pt-BR resource entries for new ViewModel messages

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adfb8d79a8832e89b5d2b5ce61e528