### PR TITLE
chore: localize update verification warning

### DIFF
--- a/src/Certify.UI.Shared/Utils/UpdateCheckUtils.cs
+++ b/src/Certify.UI.Shared/Utils/UpdateCheckUtils.cs
@@ -47,7 +47,7 @@ namespace Certify.UI.Utils
                     }
                     else
                     {
-                        MessageBox.Show(Application.Current.MainWindow, "The application update failed secondary verification. A malicious process may have changed the setup file after the downloaded completed.", ConfigResources.AppName);
+                        MessageBox.Show(Application.Current.MainWindow, "A atualização do aplicativo falhou na verificação secundária. Um processo malicioso pode ter alterado o arquivo de instalação após o download.", ConfigResources.AppName);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- translate secondary verification failure warning to Portuguese

## Testing
- `dotnet test src/Certify.UI.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae163742a4832e981c23956512026e