### PR TITLE
Translate external deletion warning

### DIFF
--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.ManagedCertificates.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.ManagedCertificates.cs
@@ -201,7 +201,7 @@ namespace Certify.UI.ViewModel
             {
                 if (existing.ItemType == ManagedCertificateType.SSL_ExternallyManaged)
                 {
-                    MessageBox.Show("This item is externally managed and cannot be deleted by this app.");
+                    MessageBox.Show("Este item é gerenciado externamente e não pode ser excluído por este aplicativo.");
 
                     return false;
                 }


### PR DESCRIPTION
## Summary
- localize message for externally managed certificate deletion to Portuguese

## Testing
- `dotnet test` *(fails: command not found; attempted `apt-get update` but repository access was denied)*

------
https://chatgpt.com/codex/tasks/task_e_68ae173e4d04832eae61d55e47fa25c4