### PR TITLE
fix: translate browser launch error message

### DIFF
--- a/src/Certify.UI.Shared/Utils/Helpers.cs
+++ b/src/Certify.UI.Shared/Utils/Helpers.cs
@@ -14,7 +14,7 @@ namespace Certify.UI.Utils
             }
             catch (Exception)
             {
-                MessageBox.Show("Could not start a browser for " + url);
+                MessageBox.Show("Não foi possível iniciar um navegador para " + url);
             }
         }
     }


### PR DESCRIPTION
## Summary
- translate "Could not start a browser" message to Portuguese

## Testing
- `dotnet test src/Certify.UI.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository InRelease not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae17c0b214832eb31dedee055c67e6