### PR TITLE
Localize preferences save error message

### DIFF
--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Settings.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.Settings.cs
@@ -141,7 +141,7 @@ namespace Certify.UI.ViewModel
             }
             catch (ServiceCommsException ex)
             {
-                MessageBox.Show($"Unable to save preferences. {ex?.Message}.", "Save Preferences Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show($"Não foi possível salvar as preferências. {ex?.Message}.", "Erro ao salvar preferências", MessageBoxButton.OK, MessageBoxImage.Error);
 
             }
             catch


### PR DESCRIPTION
## Summary
- Translate preferences save failure message to Portuguese

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae19076348832ea326566b929211cf