### PR TITLE
Translate diagnostics message strings to Portuguese

### DIFF
--- a/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.cs
+++ b/src/Certify.UI.Shared/ViewModel/AppViewModel/AppViewModel.cs
@@ -164,7 +164,7 @@ namespace Certify.UI.ViewModel
             IsError = true;
             CurrentError = exp.Message;
 
-            SystemDiagnosticError = "An error occurred. Persistent errors should be reported to AutoSSL support: " + exp.Message;
+            SystemDiagnosticError = "Ocorreu um erro. Erros persistentes devem ser relatados ao suporte AutoSSL: " + exp.Message;
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace Certify.UI.ViewModel
         /// </summary>
         /// <param name="arg1"></param>
         /// <param name="arg2"></param>
-        private void CertifyClient_SendMessage(string arg1, string arg2) => MessageBox.Show($"Received: {arg1} {arg2}");
+        private void CertifyClient_SendMessage(string arg1, string arg2) => MessageBox.Show($"Recebido: {arg1} {arg2}");
 
         public Application GetApplication() => System.Windows.Application.Current;
 


### PR DESCRIPTION
## Summary
- translate system diagnostic error text to Portuguese
- translate service message box to Portuguese

## Testing
- `dotnet build src/Certify.UI.Shared/Certify.UI.Shared.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1b434984832e834b083197f2651e