### PR TITLE
Translate log viewer error messages to Portuguese

### DIFF
--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/StatusInfo.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/StatusInfo.xaml.cs
@@ -87,7 +87,7 @@ namespace Certify.UI.Controls.ManagedCertificate
                 }
                 catch
                 {
-                    MessageBox.Show($"The system could not launch the default app for {logPath} - Open the file manually.");
+                    MessageBox.Show($"O sistema não conseguiu iniciar o aplicativo padrão para {logPath} - Abra o arquivo manualmente.");
                 }
             }
             else
@@ -110,12 +110,12 @@ namespace Certify.UI.Controls.ManagedCertificate
                     }
                     catch
                     {
-                        MessageBox.Show($"The system could not launch the default app for {logPath} - Open the file manually.");
+                        MessageBox.Show($"O sistema não conseguiu iniciar o aplicativo padrão para {logPath} - Abra o arquivo manualmente.");
                     }
                 }
                 catch (Exception exp)
                 {
-                    MessageBox.Show("Failed to fetch log file. " + exp);
+                    MessageBox.Show("Falha ao obter o arquivo de log. " + exp);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- localize log view error messages to Portuguese

## Testing
- `dotnet test src/Certify.Tests/Certify.Tests.csproj` *(failed: command not found)*
- `apt-get update` *(failed: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1d53d010832e81005aa91dd4a05d