### PR TITLE
Translate update prompt to Portuguese

### DIFF
--- a/src/Certify.UI.Shared/Controls/AboutControl.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/AboutControl.xaml.cs
@@ -59,7 +59,7 @@ namespace Certify.UI.Controls
                 {
                     MainViewModel.IsUpdateAvailable = true;
 
-                    var gotoDownload = MessageBox.Show(updateCheck.Message.Body + "\r\nVisit download page now?", ConfigResources.AppName, MessageBoxButton.YesNo);
+                    var gotoDownload = MessageBox.Show(updateCheck.Message.Body + "\r\nVisitar página de download agora?", ConfigResources.AppName, MessageBoxButton.YesNo);
                     if (gotoDownload == MessageBoxResult.Yes)
                     {
                         Utils.Helpers.LaunchBrowser(ConfigResources.AppWebsiteURL);


### PR DESCRIPTION
## Summary
- translate update prompt message to Portuguese in AboutControl

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2647a8a4832eabe72671bfed6bcf