### PR TITLE
Update default export filename to AutoSSL_Export

### DIFF
--- a/src/Certify.UI.Shared/Windows/ImportExport.xaml.cs
+++ b/src/Certify.UI.Shared/Windows/ImportExport.xaml.cs
@@ -253,7 +253,7 @@ namespace Certify.UI.Windows
             var dialog = new SaveFileDialog();
 
             // prompt user for save file location and perform export to json file
-            dialog.FileName = $"certifytheweb_export_{DateTime.Now.ToString("yyyyMMdd")}.json";
+            dialog.FileName = $"AutoSSL_Export_{DateTime.Now:yyyyMMdd}.json";
             dialog.DefaultExt = "json";
             dialog.Filter = "Arquivos JSON (*.json)|*.json|Todos os arquivos (*.*)|*.*";
 


### PR DESCRIPTION
## Summary
- update settings export dialog to suggest `AutoSSL_Export_YYYYMMDD.json` as default filename

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b0be4eec832ea6c6c86ce0e44ddc