### PR TITLE
chore: update backup export filename prefix

### DIFF
--- a/src/Certify.CLI/CertifyCLI.Backup.cs
+++ b/src/Certify.CLI/CertifyCLI.Backup.cs
@@ -16,7 +16,7 @@ namespace Certify.CLI
 
             if (Directory.Exists(filename))
             {
-                filename = Path.Combine(filename, $"certifytheweb_export_{DateTime.Now.ToString("yyyyMMdd")}.json");
+                filename = Path.Combine(filename, $"AutoSSL_Export_{DateTime.Now:yyyyMMdd}.json");
             }
 
             Console.ForegroundColor = ConsoleColor.White;


### PR DESCRIPTION
## Summary
- rename backup export prefix to AutoSSL_Export

## Testing
- ❌ `dotnet build src/Certify.CLI/Certify.CLI.csproj` *(dotnet: command not found)*
- ⚠️ `curl -SL https://dot.net/v1/dotnet-install.sh` *(403 CONNECT tunnel failed)*
- ❌ `dotnet run --project src/Certify.CLI/Certify.CLI.csproj -- backup export /tmp secret` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b0c5ce20832ea7b6ad680e44bacf