### PR TITLE
feat: export separate PEM files

### DIFF
--- a/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
+++ b/src/Certify.Providers/ACME/Anvil/AnvilACMEProvider.cs
@@ -1649,7 +1649,7 @@ namespace Certify.Providers.ACME.Anvil
 
             if (DefaultCertificateFormat == "pem" || DefaultCertificateFormat == "all")
             {
-                var pemOutputFile = ExportFullCertPEM(csrKey, certificateChain, primaryIdentifierAsPath);
+                var pemOutputFile = ExportFullCertPEM(csrKey, certificateChain, certId, primaryIdentifierAsPath);
 
                 if (string.IsNullOrEmpty(primaryCertOutputFile))
                 {
@@ -2079,7 +2079,7 @@ namespace Certify.Providers.ACME.Anvil
             catch { }
         }
 
-        private string ExportFullCertPEM(IKey csrKey, CertificateChain certificateChain, string primaryIdentifierPath)
+        private string ExportFullCertPEM(IKey csrKey, CertificateChain certificateChain, string certId, string primaryIdentifierPath)
         {
             var storePath = Path.GetFullPath(Path.Combine(new string[] { _providerSettings.ServiceSettingsBasePath, "assets", primaryIdentifierPath }));
 
@@ -2107,7 +2107,21 @@ namespace Certify.Providers.ACME.Anvil
             var fullchainPath = Path.GetFullPath(Path.Combine(new string[] { storePath, "fullchain.pem" }));
             File.WriteAllText(fullchainPath, certificateChain.ToPem());
 
-            return fullchainPath;
+            // export additional separate files using primary identifier and cert id as prefix
+            var prefix = $"{primaryIdentifierPath}-{certId}";
+
+            var certPath = Path.GetFullPath(Path.Combine(new string[] { storePath, $"{prefix}.crt" }));
+            File.WriteAllText(certPath, certificateChain.Certificate.ToPem());
+
+            var keyPath = Path.GetFullPath(Path.Combine(new string[] { storePath, $"{prefix}.key" }));
+            File.WriteAllText(keyPath, csrKey.ToPem());
+
+            // remaining chain (intermediate/root)
+            var caCerts = certificateChain.ToPem().Replace(certificateChain.Certificate.ToPem(), string.Empty).Trim();
+            var caPath = Path.GetFullPath(Path.Combine(new string[] { storePath, "ca.crt" }));
+            File.WriteAllText(caPath, caCerts);
+
+            return certPath;
         }
 
         public async Task<StatusMessage> RevokeCertificate(ILog log, ManagedCertificate managedCertificate)

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/Deployment.xaml
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/Deployment.xaml
@@ -100,6 +100,7 @@
                         <TextBox Width="225" Text="{Binding SelectedItem.RequestConfig.CustomCertificateDirectory}" />
                         <Button Margin="4,0,0,0" Click="CustomCertDirBrowse_Click" Content="{x:Static Resources:SR.ManagedCertificateSettings_BrowseFolder}" />
                     </StackPanel>
+                    <Button Margin="160,8,0,0" Click="ExportSeparatePem_Click">Gerar arquivos separados</Button>
                 </StackPanel>
             </DockPanel>
 

--- a/src/Certify.UI.Shared/Controls/ManagedCertificate/Deployment.xaml.cs
+++ b/src/Certify.UI.Shared/Controls/ManagedCertificate/Deployment.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using Certify.UI.Windows;
@@ -112,6 +113,11 @@ namespace Certify.UI.Controls.ManagedCertificate
                 Owner = Window.GetWindow(this)
             };
             dialog.ShowDialog();
+        }
+
+        private async void ExportSeparatePem_Click(object sender, RoutedEventArgs e)
+        {
+            await ItemViewModel.ExportSeparatePem();
         }
     }
 }

--- a/src/Certify.UI.Shared/ViewModel/ManagedCertificateViewModel.cs
+++ b/src/Certify.UI.Shared/ViewModel/ManagedCertificateViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -11,6 +12,7 @@ using Certify.Models;
 using Certify.Models.Config;
 using Certify.Models.Shared.Validation;
 using Certify.Models.Utils;
+using Certify.Shared.Core.Utils.PKI;
 using PropertyChanged;
 
 namespace Certify.UI.ViewModel
@@ -683,6 +685,52 @@ namespace Certify.UI.ViewModel
                 }
 
                 return _parsedTokenList;
+            }
+        }
+
+        public async Task ExportSeparatePem()
+        {
+            var item = SelectedItem;
+            if (item == null)
+            {
+                return;
+            }
+
+            var exportDir = item.RequestConfig?.CustomCertificateDirectory;
+            if (string.IsNullOrWhiteSpace(exportDir))
+            {
+                _appViewModel.ShowNotification("Diretório de exportação não definido", NotificationType.Warning);
+                return;
+            }
+
+            try
+            {
+                var pfxPath = item.CertificatePath;
+                if (string.IsNullOrWhiteSpace(pfxPath) || !File.Exists(pfxPath))
+                {
+                    _appViewModel.ShowNotification("Certificado não encontrado para exportação", NotificationType.Error);
+                    return;
+                }
+
+                Directory.CreateDirectory(exportDir);
+
+                var pfxData = await File.ReadAllBytesAsync(pfxPath);
+                var prefix = $"{item.RequestConfig?.PrimaryDomain}-{item.Id}";
+
+                var certPem = CertUtils.GetCertComponentsAsPEMString(pfxData, "", ExportFlags.EndEntityCertificate);
+                await File.WriteAllTextAsync(Path.Combine(exportDir, $"{prefix}.crt"), certPem);
+
+                var keyPem = CertUtils.GetCertComponentsAsPEMString(pfxData, "", ExportFlags.PrivateKey);
+                await File.WriteAllTextAsync(Path.Combine(exportDir, $"{prefix}.key"), keyPem);
+
+                var caPem = CertUtils.GetCertComponentsAsPEMString(pfxData, "", ExportFlags.IntermediateCertificates | ExportFlags.RootCertificate);
+                await File.WriteAllTextAsync(Path.Combine(exportDir, "ca.crt"), caPem);
+
+                _appViewModel.ShowNotification("Arquivos separados exportados", NotificationType.Success);
+            }
+            catch (Exception exp)
+            {
+                _appViewModel.ShowNotification($"Falha ao exportar: {exp.Message}", NotificationType.Error);
             }
         }
 


### PR DESCRIPTION
## Summary
- extend Anvil ACME provider to output separate certificate, key and CA files using a prefix
- add UI button to generate separate PEM files
- support separate PEM export in managed certificate view model

## Testing
- `dotnet build src/Certify.UI.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 error)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d68b3c48832ebde5b15e1186e670